### PR TITLE
Add logic to prioritize events

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,14 @@ import { InvocationRequest } from 'aws-sdk/clients/lambda';
 import { getStatusForUserEvent } from './utils/map-event-status';
 
 const getHighestPriorityEvent = (events: CalendarEvent[]) => {
-  // TODO: Implement this function to resolve the event to use for status updates from a list of user events
-  return events.length ? events[0] : null;
+  const now: Date = new Date();
+  const ninetySecondsFromNow: Date = new Date();
+  ninetySecondsFromNow.setSeconds(ninetySecondsFromNow.getSeconds() + 90);
+
+  const eventsHappeningNow: CalendarEvent[] = events
+    .filter(e => e.startDate <= ninetySecondsFromNow && now < e.endDate)
+    .sort((event1, event2) => event2.showAs - event1.showAs);
+  return eventsHappeningNow.length ? eventsHappeningNow[0] : null;
 };
 
 export const update: Handler = async () => {

--- a/src/services/calendar.ts
+++ b/src/services/calendar.ts
@@ -1,7 +1,7 @@
 export enum ShowAs {
   Free = 1,
-  Busy,
   Tentative,
+  Busy,
   OutOfOffice,
 }
 


### PR DESCRIPTION
Adds a little bit of logic to sort the events by date and `showAs` status to determine which one (if any) to use to set the Slack status.