### PR TITLE
Revoke access

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -64,12 +64,12 @@ export const updateBatch: Handler = async (event: any) => {
       const status = getStatusForUserEvent(us, relevantEvent);
 
       console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${us.email}`);
-      await setUserStatus(us.slackToken, status);
+      await setUserStatus(us.email, us.slackToken, status);
 
       const presence = relevantEvent && relevantEvent.showAs < ShowAs.Busy ? 'auto' : 'away';
 
       console.log(`Setting presence to '${presence}' for ${us.email}`);
-      await setUserPresence(us.slackToken, presence);
+      await setUserPresence(us.email, us.slackToken, presence);
     }),
   );
 };

--- a/src/services/calendar/calendar.ts
+++ b/src/services/calendar/calendar.ts
@@ -1,6 +1,7 @@
 import { Client, ClientOptions } from '@microsoft/microsoft-graph-client';
 import { GraphApiAuthenticationProvider } from './graphApiAuthenticationProvider';
 import { Token } from 'simple-oauth2';
+import { clearUserTokens } from '../../services/dynamo';
 
 export enum ShowAs {
   Free = 1,
@@ -68,6 +69,16 @@ export const getEventsForUser = async (email: string, storedToken: Token): Promi
     });
   } catch (error) {
     console.error(error);
+
+    const { statusCode } = error;
+    if (statusCode === 401 || statusCode === 403) {
+      console.error(`No authorization for Graph API for user ${email}`);
+      try {
+        await clearUserTokens(email);
+      } finally {
+        return null;
+      }
+    }
   }
 
   return [];

--- a/src/services/dynamo.ts
+++ b/src/services/dynamo.ts
@@ -14,6 +14,33 @@ export type UserSettings = {
   }[];
 };
 
+export const clearUserTokens = async (email: string): Promise<UserSettings> => {
+  const dynamoDb = new AWS.DynamoDB.DocumentClient();
+
+  return new Promise((resolve, reject) =>
+    dynamoDb.update(
+      {
+        TableName: config.dynamoDb.tableName,
+        Key: { email: email },
+        UpdateExpression: 'set calendarStoredToken = :ct, slackToken = :st',
+        ExpressionAttributeValues: {
+          ':ct': null,
+          ':st': null,
+        },
+        ReturnValues: 'ALL_NEW',
+      },
+      (err, data) => {
+        if (err) {
+          reject(err.message);
+          return;
+        }
+
+        resolve(data as UserSettings);
+      },
+    ),
+  );
+};
+
 export const storeCalendarAuthenticationToken = async (
   email: string,
   calendarStoredToken: Token,

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -1,4 +1,4 @@
-import { WebClient, WebAPICallError, WebAPIPlatformError, WebAPIHTTPError } from '@slack/web-api';
+import { WebClient } from '@slack/web-api';
 import { clearUserTokens } from './dynamo';
 
 export type SlackStatus = {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -1,23 +1,48 @@
-import { WebClient } from '@slack/web-api';
+import { WebClient, WebAPICallError, WebAPIPlatformError, WebAPIHTTPError } from '@slack/web-api';
+import { clearUserTokens } from './dynamo';
 
 export type SlackStatus = {
   text?: string;
   emoji?: string;
 };
 
-export const setUserPresence = async (token: string, presence: 'auto' | 'away') => {
+const handleError = async (error: any, email: string) => {
+  console.error(error);
+  error.data;
+  const {
+    data: { error: errorMessage },
+  } = error;
+  if (errorMessage === 'token_revoked' || errorMessage === 'invalid_auth') {
+    console.error(`No authorization for Slack for user ${email}`);
+    try {
+      await clearUserTokens(email);
+    } finally {
+      return;
+    }
+  }
+};
+
+export const setUserPresence = async (email: string, token: string, presence: 'auto' | 'away') => {
   if (!token) return;
 
   const slackClient = new WebClient(token);
 
-  await slackClient.users.setPresence({ presence });
+  try {
+    await slackClient.users.setPresence({ presence });
+  } catch (error) {
+    await handleError(error, email);
+  }
 };
 
-export const setUserStatus = async (token: string, status: SlackStatus) => {
+export const setUserStatus = async (email: string, token: string, status: SlackStatus) => {
   if (!token) return;
 
   const slackClient = new WebClient(token);
   const profile = JSON.stringify({ status_text: status.text, status_emoji: status.emoji });
 
-  await slackClient.users.profile.set({ profile });
+  try {
+    await slackClient.users.profile.set({ profile });
+  } catch (error) {
+    await handleError(error, email);
+  }
 };


### PR DESCRIPTION
Add some logic to handle invalid/revoked tokens for Slack and Graph API. Remove both tokens when one is invalid. If the user goes through the auth process again, their custom settings will be retained.