### PR TITLE
Reduce Slack calls by persisting current user events in Dynamo

### DIFF
--- a/src/services/calendar/calendar.ts
+++ b/src/services/calendar/calendar.ts
@@ -11,6 +11,7 @@ export enum ShowAs {
 }
 
 export type CalendarEvent = {
+  id: string;
   name: string;
   startTime: Date;
   endTime: Date;
@@ -64,6 +65,7 @@ export const getEventsForUser = async (email: string, storedToken: Token): Promi
 
     return outlookEvents.value.map((e: any) => {
       const event: CalendarEvent = {
+        id: e.id,
         startTime: new Date(e.start.dateTime),
         endTime: new Date(e.end.dateTime),
         location: e.location.displayName,

--- a/src/services/calendar/graphApiAuthenticationProvider.ts
+++ b/src/services/calendar/graphApiAuthenticationProvider.ts
@@ -68,11 +68,19 @@ export class GraphApiAuthenticationProvider implements AuthenticationProvider {
     return new Promise(async (resolve, reject) => {
       if (this.storedToken) {
         if (this.shouldRefreshToken(this.storedToken)) {
+          console.log(
+            `Microsoft Graph access token expired for ${this.userEmail} at ${
+              this.storedToken.expires_at_timestamp
+            }. Refreshing...`,
+          );
           try {
             const authentication = await this.createOAuthClient();
             const accessToken = authentication.accessToken.create(this.storedToken);
             const newToken = (await accessToken.refresh()).token;
             newToken.expires_at_timestamp = newToken.expires_at.toISOString();
+            console.log(
+              `Refreshed Microsoft graph token for ${this.userEmail} with expiration: ${newToken.expires_at_timestamp}`,
+            );
             await storeCalendarAuthenticationToken(this.userEmail, newToken);
             resolve(newToken.access_token);
           } catch (error) {

--- a/src/services/calendar/graphApiAuthenticationProvider.ts
+++ b/src/services/calendar/graphApiAuthenticationProvider.ts
@@ -40,7 +40,7 @@ export class GraphApiAuthenticationProvider implements AuthenticationProvider {
     }
     const now = new Date();
     const expiration = new Date(expiresAtTimestamp);
-    expiration.setMinutes(expiration.getMinutes() + 1);
+    expiration.setMinutes(expiration.getMinutes() - 1);
     return now >= expiration;
   }
 

--- a/src/services/calendar/graphApiAuthenticationProvider.ts
+++ b/src/services/calendar/graphApiAuthenticationProvider.ts
@@ -34,7 +34,7 @@ export class GraphApiAuthenticationProvider implements AuthenticationProvider {
     });
   }
 
-  private async shouldRefreshToken({ expires_at_timestamp: expiresAtTimestamp }: Token): Promise<boolean> {
+  private shouldRefreshToken({ expires_at_timestamp: expiresAtTimestamp }: Token) {
     if (!expiresAtTimestamp) {
       return true;
     }
@@ -45,53 +45,54 @@ export class GraphApiAuthenticationProvider implements AuthenticationProvider {
   }
 
   public async getTokenWithAuthCode(authCode: string): Promise<Token> {
-    return new Promise(async (resolve, reject) => {
-      const tokenConfig = {
-        scope: this.scope,
-        code: authCode || '',
-        redirect_uri: authorizeMicrosoftGraphUrl(),
-      };
-      try {
-        const authentication = await this.createOAuthClient();
-        const result = await authentication.authorizationCode.getToken(tokenConfig);
-        const { token } = authentication.accessToken.create(result);
-        token.expires_at_timestamp = token.expires_at.toISOString();
-        await storeCalendarAuthenticationToken(this.userEmail, token);
-        resolve(token);
-      } catch (error) {
-        reject(error);
-      }
-    });
+    const tokenConfig = {
+      scope: this.scope,
+      code: authCode || '',
+      redirect_uri: authorizeMicrosoftGraphUrl(),
+    };
+
+    const authentication = await this.createOAuthClient();
+    const result = await authentication.authorizationCode.getToken(tokenConfig);
+    const { token } = authentication.accessToken.create(result);
+    token.expires_at_timestamp = token.expires_at.toISOString();
+
+    await storeCalendarAuthenticationToken(this.userEmail, token);
+    return token;
   }
 
   public async getAccessToken(): Promise<any> {
-    return new Promise(async (resolve, reject) => {
-      if (this.storedToken) {
-        if (this.shouldRefreshToken(this.storedToken)) {
-          console.log(
-            `Microsoft Graph access token expired for ${this.userEmail} at ${
-              this.storedToken.expires_at_timestamp
-            }. Refreshing...`,
-          );
-          try {
-            const authentication = await this.createOAuthClient();
-            const accessToken = authentication.accessToken.create(this.storedToken);
-            const newToken = (await accessToken.refresh()).token;
-            newToken.expires_at_timestamp = newToken.expires_at.toISOString();
-            console.log(
-              `Refreshed Microsoft graph token for ${this.userEmail} with expiration: ${newToken.expires_at_timestamp}`,
-            );
-            await storeCalendarAuthenticationToken(this.userEmail, newToken);
-            resolve(newToken.access_token);
-          } catch (error) {
-            console.error(error);
-            reject(error);
-          }
-        }
-        resolve(this.storedToken.access_token);
-      } else {
-        reject(`Could not authenticate user ${this.userEmail} with Microsoft Graph`);
-      }
-    });
+    if (!this.storedToken) {
+      throw new Error(`Could not authenticate user ${this.userEmail} with Microsoft Graph`);
+    }
+
+    if (!this.shouldRefreshToken(this.storedToken)) {
+      return this.storedToken.access_token;
+    }
+
+    console.log(
+      `Microsoft Graph access token expired for ${this.userEmail} at ${
+        this.storedToken.expires_at_timestamp
+      }. Refreshing...`,
+    );
+
+    try {
+      const authentication = await this.createOAuthClient();
+      const accessToken = authentication.accessToken.create(this.storedToken);
+
+      const newToken = (await accessToken.refresh()).token;
+      newToken.expires_at_timestamp = newToken.expires_at.toISOString();
+
+      console.log(
+        `Refreshed Microsoft graph access token for ${this.userEmail} with expiration: ${
+          newToken.expires_at_timestamp
+        }`,
+      );
+
+      await storeCalendarAuthenticationToken(this.userEmail, newToken);
+      return newToken.access_token;
+    } catch (error) {
+      console.error(error);
+      throw error;
+    }
   }
 }

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -30,8 +30,10 @@ const handleError = async (error: any, email: string) => {
   }
 };
 
-export const setUserPresence = async (email: string, token: string, presence: 'auto' | 'away') => {
+export const setUserPresence = async (email: string, token: string | undefined, presence: 'auto' | 'away') => {
   if (!token) return;
+
+  console.log(`Setting presence to '${presence}' for ${email}`);
 
   const slackClient = new WebClient(token);
 
@@ -42,8 +44,10 @@ export const setUserPresence = async (email: string, token: string, presence: 'a
   }
 };
 
-export const setUserStatus = async (email: string, token: string, status: SlackStatus) => {
+export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
+
+  console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email}`);
 
   const slackClient = new WebClient(token);
   const profile = JSON.stringify({ status_text: status.text || '', status_emoji: status.emoji || '' });

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -141,7 +141,7 @@ const handleSet = async (userSettings: UserSettings, args: CommandArguments): Pr
   }
 
   const slackPromise =
-    userSettings.currentEvent && userSettings.currentEvent.name.toLowerCase().includes(args.meeting)
+    userSettings.currentEvent && userSettings.currentEvent.name.toLowerCase().includes(args.meeting.toLowerCase())
       ? setUserStatus(userSettings.email, userSettings.slackToken, slackStatus)
       : Promise.resolve();
 
@@ -177,11 +177,13 @@ const handleSetDefault = async (userSettings: UserSettings, args: CommandArgumen
     return 'Please set a default `message` and/or `emoji`.';
   }
 
+  const slackStatus = { text: message, emoji };
+
   const slackPromise = !userSettings.currentEvent
-    ? setUserStatus(userSettings.email, userSettings.slackToken, { text: message, emoji })
+    ? setUserStatus(userSettings.email, userSettings.slackToken, slackStatus)
     : Promise.resolve();
 
-  await Promise.all([upsertDefaultStatus(userSettings.email, { text: message, emoji }), slackPromise]);
+  await Promise.all([upsertDefaultStatus(userSettings.email, slackStatus), slackPromise]);
 
   const emojiString = emoji ? ` ${emoji}` : '';
   const messageString = message ? ` \`${message}\`` : '';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,7 +37,7 @@
 
     /* Module Resolution Options */
     // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    "baseUrl": "./src",
+    // "baseUrl": "./src",
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     "typeRoots": ["node_modules/@types"],


### PR DESCRIPTION
Adds a new possible column, `currentEvent`, to our DynamoDB documents which stores a document of each user's current calendar event. As `update-batch` is called over time, it compares the ID of this event with the fresh event pulled from Office365 to decide whether or not to update the user's Slack status and presence. When it *does* update, it also overwrites this event in the database.

**Note:** _I also added logging around and tried to fix up our Graph auth token refreshes because Jamie and I noticed them updating **much** more frequently than every hour—the likely culprit for why we can't perform writes from the DynamoDB console. The root cause of the constant updates was that we were declaring `shouldRefreshToken` as `async` but not `await`ing it in the calling code, making `if (this.shouldRefreshToken(...))` always truthy._