### PR TITLE
Change event prioritization to prefer upcoming events over current ones

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -23,7 +23,11 @@ type GetProfileResult = {
 };
 
 const getHighestPriorityEvent = (events: CalendarEvent[]) =>
-  events.length ? events.sort((event1, event2) => event2.showAs - event1.showAs)[0] : null;
+  events.length
+    ? events.sort(
+        (event1, event2) => event2.startTime.getTime() - event1.startTime.getTime() || event2.showAs - event1.showAs,
+      )[0]
+    : null;
 
 const microsoftAuthRedirect = (email: string) => ({
   statusCode: 301,

--- a/src/services/calendar/calendar.ts
+++ b/src/services/calendar/calendar.ts
@@ -59,7 +59,6 @@ export const getEventsForUser = async (email: string, storedToken: Token): Promi
   try {
     const outlookEvents = await getAuthenticatedClient(email, storedToken)
       .api(`/users/${email}/calendarView?startDateTime=${startTime.toISOString()}&endDateTime=${endTime.toISOString()}`)
-      .orderby('start/dateTime')
       .select('start,end,subject,showAs,location,sensitivity')
       .get();
 


### PR DESCRIPTION
Old logic: sort events by start time ascending (earliest to latest), then *separately* sort them by `ShowAs` value (OOO being highest priority, then Busy, then Tentative, then Free).

New logic: sort events by start time descending (latest to earliest); if two events have the same start time, prefer the one with the higher `ShowAs` value (same as before).

**Keep in mind that the events being sorted here are only events happening within +/- 1min of the current time**