### PR TITLE
Add Slackbot command to update bot settings for user

### DIFF
--- a/src/services/dynamo.ts
+++ b/src/services/dynamo.ts
@@ -16,6 +16,7 @@ export type UserSettings = {
   defaultStatus?: SlackStatus;
   statusMappings?: StatusMapping[];
   currentEvent?: CalendarEvent;
+  zoomLinksDisabled?: boolean;
 };
 
 const toDynamoStatus = (status: SlackStatus) => ({
@@ -292,6 +293,34 @@ export const getSettingsForUsers = async (emails: string[]): Promise<UserSetting
         }
 
         resolve(data.Responses ? (data.Responses[config.dynamoDb.tableName] as UserSettings[]) : []);
+      },
+    ),
+  );
+};
+
+export const setZoomLinksDisabled = async (email: string, zoomLinksDisabled: boolean): Promise<UserSettings> => {
+  const dynamoDb = new AWS.DynamoDB.DocumentClient();
+
+  return new Promise((resolve, reject) =>
+    dynamoDb.update(
+      {
+        TableName: config.dynamoDb.tableName,
+        Key: {
+          email,
+        },
+        UpdateExpression: 'set zoomLinksDisabled = :z',
+        ExpressionAttributeValues: {
+          ':z': zoomLinksDisabled,
+        },
+        ReturnValues: 'ALL_NEW',
+      },
+      (err, data) => {
+        if (err) {
+          reject(err.message);
+          return;
+        }
+
+        resolve(data.Attributes as UserSettings);
       },
     ),
   );

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -122,7 +122,7 @@ const constructSettingsCommandArgs = (argList: string[]): SettingsCommandArgumen
   }
 
   return {
-    zoomLinksEnabled: args['zoom-links'].length ? args['zoom-links'] === 'true' : undefined,
+    zoomLinksEnabled: args['zoom-links'].length ? args['zoom-links'].toLowerCase() === 'true' : undefined,
   };
 };
 

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -112,7 +112,7 @@ const constructCalendarCommandArgs = (argList: string[]): CalendarCommandArgumen
 };
 
 const constructSettingsCommandArgs = (argList: string[]): SettingsCommandArguments => {
-  const args: { [key: string]: string } = { 'zoom-links': 'true' };
+  const args: { [key: string]: string } = { 'zoom-links': '' };
 
   for (let arg of argList) {
     const [key, value] = arg.split('=');
@@ -122,7 +122,7 @@ const constructSettingsCommandArgs = (argList: string[]): SettingsCommandArgumen
   }
 
   return {
-    zoomLinksEnabled: args['zoom-links'] === 'true',
+    zoomLinksEnabled: args['zoom-links'].length ? args['zoom-links'] === 'true' : undefined,
   };
 };
 
@@ -227,7 +227,9 @@ const handleRemoveDefault = async (userSettings: UserSettings): Promise<string> 
 const handleUpdateSettings = async (userSettings: UserSettings, argList: string[]): Promise<string> => {
   const args = constructSettingsCommandArgs(argList);
 
-  await setZoomLinksDisabled(userSettings.email, !args.zoomLinksEnabled);
+  if (args.zoomLinksEnabled !== undefined) {
+    await setZoomLinksDisabled(userSettings.email, !args.zoomLinksEnabled);
+  }
 
   // TODO: Once more settings are present, change this to echo their settings
   return 'Your settings have been updated.';

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -242,7 +242,7 @@ const commandHandlerMap: {
   remove: handleRemove,
   'set-default': handleSetDefault,
   'remove-default': handleRemoveDefault,
-  'update-settings': handleUpdateSettings,
+  settings: handleUpdateSettings,
 };
 
 const handleSlackEventCallback = async ({


### PR DESCRIPTION
Adds a `settings` command to the bot that currently only takes one argument: `zoom-links=[true|false]`. Changing this to false will disable the Zoom links sent to the user for upcoming meetings.

![image](https://user-images.githubusercontent.com/2313732/62829140-9cc65480-bbbc-11e9-8c1e-33c03312fe76.png)