### PR TITLE
C2S-10 Allow spaces in commands

### DIFF
--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -108,7 +108,7 @@ const constructCalendarCommandArgs = (argList: string[]): CalendarCommandArgumen
   const args: { [key: string]: string } = { meeting: '', message: '', emoji: '' };
 
   for (let arg of argList) {
-    const [key, value] = arg.split('=');
+    const [key, value] = arg.split(/\s?=\s?/g);
     if (key in args) {
       args[key] = value.replace(/["”“]/g, '');
     }
@@ -125,7 +125,7 @@ const constructSettingsCommandArgs = (argList: string[]): SettingsCommandArgumen
   const args: { [key: string]: string } = { 'zoom-links': '' };
 
   for (let arg of argList) {
-    const [key, value] = arg.split('=');
+    const [key, value] = arg.split(/\s?=\s?/g);
     if (key in args) {
       args[key] = value.replace(/["”“]/g, '');
     }
@@ -289,9 +289,8 @@ const handleSlackEventCallback = async ({
 
 You need to authorize me before we can do anything else: ${slackInstallUrl()}`);
   }
-
   const command = text;
-  const tokens = command.match(/[\w]+=["“][^"”]+["”]|[^ "“”]+/g) || [];
+  const tokens = command.match(/[\w]+\s?=\s?["“:][^"”:]+["”:]|[^ "“”:]+/g) || [];
   const subcommand = tokens[0];
   const args = tokens.slice(1);
 


### PR DESCRIPTION
This PR just adjusts the regex used to parse out the Slackbot commands to allow for spaces between the command keys and values. The bot should now accept the following formats:
* `set meeting="Meeting Name" message="Status Message" emoji=:wave:`
* `set meeting= "Meeting Name" message= "Status Message" emoji= :wave:`
* `set meeting ="Meeting Name" message ="Status Message" emoji =:wave:`
* `set meeting = "Meeting Name" message = "Status Message" emoji = :wave:`