### PR TITLE
Fix event prioritization and OOO statuses

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -100,9 +100,7 @@ export const updateBatch: Handler = async (event: any) => {
       const botToken = await getSlackSecretWithKey('bot-token');
       const user = await getUserByEmail(botToken, us.email);
 
-      if (!user) {
-        return;
-      }
+      if (!user) return;
 
       const status = getStatusForUserEvent(us, relevantEvent, user.tz);
       const presence = relevantEvent && relevantEvent.showAs > ShowAs.Tentative ? 'away' : 'auto';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ import {
   removeCurrentEvent,
   UserSettings,
 } from './services/dynamo';
-import { setUserStatus, setUserPresence, getUserByEmail, postMessage } from './services/slack';
+import { setUserStatus, setUserPresence, getUserByEmail, postMessage, SlackUser } from './services/slack';
 import { Handler } from 'aws-lambda';
 import { InvocationRequest } from 'aws-sdk/clients/lambda';
 import { getStatusForUserEvent } from './utils/map-event-status';
@@ -26,7 +26,7 @@ type GetProfileResult = {
 const getHighestPriorityEvent = (events: CalendarEvent[]) =>
   events.length
     ? events.sort(
-        (event1, event2) => event2.startTime.getTime() - event1.startTime.getTime() || event2.showAs - event1.showAs,
+        (event1, event2) => event2.showAs - event1.showAs || event2.startTime.getTime() - event1.startTime.getTime(),
       )[0]
     : null;
 
@@ -42,7 +42,12 @@ const microsoftAuthRedirect = (email: string) => ({
 const shouldUpdate = (e1: CalendarEvent | undefined, e2: CalendarEvent | null) =>
   (!e1 && e2) || (e1 && !e2) || (e1 && e2 && e1.id !== e2.id);
 
-const sendUpcomingEventMessage = async (event: CalendarEvent | null, settings: UserSettings) => {
+const sendUpcomingEventMessage = async (
+  token: string,
+  user: SlackUser,
+  event: CalendarEvent | null,
+  settings: UserSettings,
+) => {
   if (
     settings.zoomLinksDisabled ||
     !event ||
@@ -52,12 +57,9 @@ const sendUpcomingEventMessage = async (event: CalendarEvent | null, settings: U
     return;
   }
 
-  const botToken = await getSlackSecretWithKey('bot-token');
-  const user = await getUserByEmail(botToken, settings.email);
-
   if (!user) return;
 
-  return await postMessage(botToken, { text: `Join *${event.name}* at: ${event.location}`, channel: user.id });
+  return await postMessage(token, { text: `Join *${event.name}* at: ${event.location}`, channel: user.id });
 };
 
 export const update: Handler = async () => {
@@ -95,13 +97,20 @@ export const updateBatch: Handler = async (event: any) => {
 
       if (!shouldUpdate(us.currentEvent, relevantEvent)) return;
 
-      const status = getStatusForUserEvent(us, relevantEvent);
+      const botToken = await getSlackSecretWithKey('bot-token');
+      const user = await getUserByEmail(botToken, us.email);
+
+      if (!user) {
+        return;
+      }
+
+      const status = getStatusForUserEvent(us, relevantEvent, user.tz);
       const presence = relevantEvent && relevantEvent.showAs > ShowAs.Tentative ? 'away' : 'auto';
 
       await Promise.all([
         setUserStatus(us.email, us.slackToken, status),
         setUserPresence(us.email, us.slackToken, presence),
-        sendUpcomingEventMessage(relevantEvent, us),
+        sendUpcomingEventMessage(botToken, user, relevantEvent, us),
         relevantEvent ? upsertCurrentEvent(us.email, relevantEvent) : removeCurrentEvent(us.email),
       ]);
     }),

--- a/src/services/calendar/calendar.ts
+++ b/src/services/calendar/calendar.ts
@@ -66,12 +66,13 @@ export const getEventsForUser = async (email: string, storedToken: Token): Promi
     return outlookEvents.value.map((e: any) => {
       const event: CalendarEvent = {
         id: e.id,
-        startTime: new Date(e.start.dateTime),
-        endTime: new Date(e.end.dateTime),
+        startTime: new Date(`${e.start.dateTime}Z`),
+        endTime: new Date(`${e.end.dateTime}Z`),
         location: e.location.displayName,
         showAs: toShowAsStatus(e.showAs),
         name: e.sensitivity === 'normal' ? e.subject : 'Private event',
       };
+
       return event;
     });
   } catch (error) {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -18,6 +18,7 @@ export type SlackUserProfile = {
 
 export type SlackUser = {
   id: string;
+  tz: string;
 };
 
 const handleError = async (error: any, email: string) => {

--- a/src/utils/__tests__/map-event-status-tests.ts
+++ b/src/utils/__tests__/map-event-status-tests.ts
@@ -6,14 +6,14 @@ const baseUserSettings = { email: 'test@email.com', slackToken: 'abc' };
 describe('getStatusForUserEvent', () => {
   describe('Given a null event', () => {
     test('Returns an empty status by default', () => {
-      const status = getStatusForUserEvent(baseUserSettings, null);
+      const status = getStatusForUserEvent(baseUserSettings, null, 'UTC');
 
       expect(status).toEqual({ text: '', emoji: '' });
     });
 
     test(`Returns the user's default status if present`, () => {
       const defaultStatus = { text: 'Hi', emoji: ':wave:' };
-      const status = getStatusForUserEvent({ ...baseUserSettings, defaultStatus }, null);
+      const status = getStatusForUserEvent({ ...baseUserSettings, defaultStatus }, null, 'UTC');
 
       expect(status).toEqual(defaultStatus);
     });
@@ -41,6 +41,7 @@ describe('getStatusForUserEvent', () => {
         location: 'Zoom',
         showAs: ShowAs.Busy,
       },
+      'UTC',
     );
 
     expect(status).toEqual({
@@ -74,6 +75,7 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
+        'UTC',
       );
 
       expect(status).toEqual({
@@ -106,6 +108,7 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
+        'UTC',
       );
 
       expect(status).toEqual(defaultStatus);
@@ -123,20 +126,25 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
+        'UTC',
       );
 
       expect(status).toEqual(defaultStatus);
     });
 
     test('Returns an empty status without a status mapping or default status', () => {
-      const status = getStatusForUserEvent(baseUserSettings, {
-        id: '1',
-        name: 'Quick Chat',
-        startTime: new Date(),
-        endTime: new Date(),
-        location: 'Zoom',
-        showAs: ShowAs.Free,
-      });
+      const status = getStatusForUserEvent(
+        baseUserSettings,
+        {
+          id: '1',
+          name: 'Quick Chat',
+          startTime: new Date(),
+          endTime: new Date(),
+          location: 'Zoom',
+          showAs: ShowAs.Free,
+        },
+        'UTC',
+      );
 
       expect(status).toEqual({ text: '', emoji: '' });
     });
@@ -167,6 +175,7 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Busy,
         },
+        'UTC',
       );
 
       expect(status).toEqual({
@@ -199,20 +208,25 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Busy,
         },
+        'UTC',
       );
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
 
     test(`Returns "Away" and :spiral_calendar_pad: when the user has no status mappings`, () => {
-      const status = getStatusForUserEvent(baseUserSettings, {
-        id: '1',
-        name: 'Quick Chat',
-        startTime: new Date(),
-        endTime: new Date(),
-        location: 'Zoom',
-        showAs: ShowAs.Busy,
-      });
+      const status = getStatusForUserEvent(
+        baseUserSettings,
+        {
+          id: '1',
+          name: 'Quick Chat',
+          startTime: new Date(),
+          endTime: new Date(),
+          location: 'Zoom',
+          showAs: ShowAs.Busy,
+        },
+        'UTC',
+      );
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
@@ -243,6 +257,7 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Tentative,
         },
+        'UTC',
       );
 
       expect(status).toEqual({
@@ -273,20 +288,25 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Tentative,
         },
+        'UTC',
       );
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
 
     test(`Returns "Away" and :spiral_calendar_pad: when the user has no status mappings`, () => {
-      const status = getStatusForUserEvent(baseUserSettings, {
-        id: '1',
-        name: 'Quick Chat',
-        startTime: new Date(),
-        endTime: new Date(),
-        location: 'Zoom',
-        showAs: ShowAs.Tentative,
-      });
+      const status = getStatusForUserEvent(
+        baseUserSettings,
+        {
+          id: '1',
+          name: 'Quick Chat',
+          startTime: new Date(),
+          endTime: new Date(),
+          location: 'Zoom',
+          showAs: ShowAs.Tentative,
+        },
+        'UTC',
+      );
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
@@ -317,6 +337,7 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.OutOfOffice,
         },
+        'UTC',
       );
 
       expect(status).toEqual({
@@ -328,38 +349,46 @@ describe('getStatusForUserEvent', () => {
     describe('Given no status mappings', () => {
       test(`Returns "OOO until {date}" and :ooo: when the OOO event lasts beyond the current day`, () => {
         const today = new Date();
-        const status = getStatusForUserEvent(baseUserSettings, {
-          id: '1',
-          name: 'Quick Chat',
-          startTime: new Date(),
-          endTime: {
-            ...today,
-            getDate: jest.fn(() => today.getDate() + 1),
-            toLocaleDateString: jest.fn(() => 'tomorrow'),
-            toLocaleTimeString: jest.fn(() => '2pm'),
+        const status = getStatusForUserEvent(
+          baseUserSettings,
+          {
+            id: '1',
+            name: 'Quick Chat',
+            startTime: new Date(),
+            endTime: {
+              ...today,
+              getDate: jest.fn(() => today.getDate() + 1),
+              toLocaleDateString: jest.fn(() => 'tomorrow'),
+              toLocaleTimeString: jest.fn(() => '2pm'),
+            },
+            location: 'Zoom',
+            showAs: ShowAs.OutOfOffice,
           },
-          location: 'Zoom',
-          showAs: ShowAs.OutOfOffice,
-        });
+          'UTC',
+        );
 
         expect(status).toEqual({ text: 'OOO until tomorrow', emoji: ':ooo:' });
       });
 
-      test(`Returns "OOO until {time}" and :ooo: when the OOO event ends on the current day`, () => {
+      test(`Returns "OOO until {time}" in the user's timezone and :ooo: when the OOO event ends on the current day`, () => {
         const today = new Date();
-        const status = getStatusForUserEvent(baseUserSettings, {
-          id: '1',
-          name: 'Quick Chat',
-          startTime: new Date(),
-          endTime: {
-            ...today,
-            getDate: jest.fn(() => today.getDate()),
-            toLocaleDateString: jest.fn(() => 'tomorrow'),
-            toLocaleTimeString: jest.fn(() => '2pm'),
+        const status = getStatusForUserEvent(
+          baseUserSettings,
+          {
+            id: '1',
+            name: 'Quick Chat',
+            startTime: new Date(),
+            endTime: {
+              ...today,
+              getDate: jest.fn(() => today.getDate()),
+              toLocaleDateString: jest.fn(() => 'tomorrow'),
+              toLocaleTimeString: jest.fn(() => '2pm'),
+            },
+            location: 'Zoom',
+            showAs: ShowAs.OutOfOffice,
           },
-          location: 'Zoom',
-          showAs: ShowAs.OutOfOffice,
-        });
+          'UTC',
+        );
 
         expect(status).toEqual({ text: 'OOO until 2pm', emoji: ':ooo:' });
       });
@@ -394,6 +423,7 @@ describe('getStatusForUserEvent', () => {
             location: 'Zoom',
             showAs: ShowAs.OutOfOffice,
           },
+          'UTC',
         );
 
         expect(status).toEqual({ text: 'OOO until tomorrow', emoji: ':ooo:' });
@@ -427,6 +457,7 @@ describe('getStatusForUserEvent', () => {
             location: 'Zoom',
             showAs: ShowAs.OutOfOffice,
           },
+          'UTC',
         );
 
         expect(status).toEqual({ text: 'OOO until 2pm', emoji: ':ooo:' });

--- a/src/utils/__tests__/map-event-status-tests.ts
+++ b/src/utils/__tests__/map-event-status-tests.ts
@@ -6,14 +6,14 @@ const baseUserSettings = { email: 'test@email.com', slackToken: 'abc' };
 describe('getStatusForUserEvent', () => {
   describe('Given a null event', () => {
     test('Returns an empty status by default', () => {
-      const status = getStatusForUserEvent(baseUserSettings, null, 'UTC');
+      const status = getStatusForUserEvent(baseUserSettings, null);
 
       expect(status).toEqual({ text: '', emoji: '' });
     });
 
     test(`Returns the user's default status if present`, () => {
       const defaultStatus = { text: 'Hi', emoji: ':wave:' };
-      const status = getStatusForUserEvent({ ...baseUserSettings, defaultStatus }, null, 'UTC');
+      const status = getStatusForUserEvent({ ...baseUserSettings, defaultStatus }, null);
 
       expect(status).toEqual(defaultStatus);
     });
@@ -41,7 +41,6 @@ describe('getStatusForUserEvent', () => {
         location: 'Zoom',
         showAs: ShowAs.Busy,
       },
-      'UTC',
     );
 
     expect(status).toEqual({
@@ -75,7 +74,6 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
-        'UTC',
       );
 
       expect(status).toEqual({
@@ -108,7 +106,6 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
-        'UTC',
       );
 
       expect(status).toEqual(defaultStatus);
@@ -126,25 +123,20 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
-        'UTC',
       );
 
       expect(status).toEqual(defaultStatus);
     });
 
     test('Returns an empty status without a status mapping or default status', () => {
-      const status = getStatusForUserEvent(
-        baseUserSettings,
-        {
-          id: '1',
-          name: 'Quick Chat',
-          startTime: new Date(),
-          endTime: new Date(),
-          location: 'Zoom',
-          showAs: ShowAs.Free,
-        },
-        'UTC',
-      );
+      const status = getStatusForUserEvent(baseUserSettings, {
+        id: '1',
+        name: 'Quick Chat',
+        startTime: new Date(),
+        endTime: new Date(),
+        location: 'Zoom',
+        showAs: ShowAs.Free,
+      });
 
       expect(status).toEqual({ text: '', emoji: '' });
     });
@@ -175,7 +167,6 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Busy,
         },
-        'UTC',
       );
 
       expect(status).toEqual({
@@ -208,25 +199,20 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Busy,
         },
-        'UTC',
       );
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
 
     test(`Returns "Away" and :spiral_calendar_pad: when the user has no status mappings`, () => {
-      const status = getStatusForUserEvent(
-        baseUserSettings,
-        {
-          id: '1',
-          name: 'Quick Chat',
-          startTime: new Date(),
-          endTime: new Date(),
-          location: 'Zoom',
-          showAs: ShowAs.Busy,
-        },
-        'UTC',
-      );
+      const status = getStatusForUserEvent(baseUserSettings, {
+        id: '1',
+        name: 'Quick Chat',
+        startTime: new Date(),
+        endTime: new Date(),
+        location: 'Zoom',
+        showAs: ShowAs.Busy,
+      });
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
@@ -257,7 +243,6 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Tentative,
         },
-        'UTC',
       );
 
       expect(status).toEqual({
@@ -288,25 +273,20 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.Tentative,
         },
-        'UTC',
       );
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
 
     test(`Returns "Away" and :spiral_calendar_pad: when the user has no status mappings`, () => {
-      const status = getStatusForUserEvent(
-        baseUserSettings,
-        {
-          id: '1',
-          name: 'Quick Chat',
-          startTime: new Date(),
-          endTime: new Date(),
-          location: 'Zoom',
-          showAs: ShowAs.Tentative,
-        },
-        'UTC',
-      );
+      const status = getStatusForUserEvent(baseUserSettings, {
+        id: '1',
+        name: 'Quick Chat',
+        startTime: new Date(),
+        endTime: new Date(),
+        location: 'Zoom',
+        showAs: ShowAs.Tentative,
+      });
 
       expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
     });
@@ -337,7 +317,6 @@ describe('getStatusForUserEvent', () => {
           location: 'Zoom',
           showAs: ShowAs.OutOfOffice,
         },
-        'UTC',
       );
 
       expect(status).toEqual({
@@ -349,46 +328,38 @@ describe('getStatusForUserEvent', () => {
     describe('Given no status mappings', () => {
       test(`Returns "OOO until {date}" and :ooo: when the OOO event lasts beyond the current day`, () => {
         const today = new Date();
-        const status = getStatusForUserEvent(
-          baseUserSettings,
-          {
-            id: '1',
-            name: 'Quick Chat',
-            startTime: new Date(),
-            endTime: {
-              ...today,
-              getDate: jest.fn(() => today.getDate() + 1),
-              toLocaleDateString: jest.fn(() => 'tomorrow'),
-              toLocaleTimeString: jest.fn(() => '2pm'),
-            },
-            location: 'Zoom',
-            showAs: ShowAs.OutOfOffice,
+        const status = getStatusForUserEvent(baseUserSettings, {
+          id: '1',
+          name: 'Quick Chat',
+          startTime: new Date(),
+          endTime: {
+            ...today,
+            getDate: jest.fn(() => today.getDate() + 1),
+            toLocaleDateString: jest.fn(() => 'tomorrow'),
+            toLocaleTimeString: jest.fn(() => '2pm'),
           },
-          'UTC',
-        );
+          location: 'Zoom',
+          showAs: ShowAs.OutOfOffice,
+        });
 
         expect(status).toEqual({ text: 'OOO until tomorrow', emoji: ':ooo:' });
       });
 
       test(`Returns "OOO until {time}" in the user's timezone and :ooo: when the OOO event ends on the current day`, () => {
         const today = new Date();
-        const status = getStatusForUserEvent(
-          baseUserSettings,
-          {
-            id: '1',
-            name: 'Quick Chat',
-            startTime: new Date(),
-            endTime: {
-              ...today,
-              getDate: jest.fn(() => today.getDate()),
-              toLocaleDateString: jest.fn(() => 'tomorrow'),
-              toLocaleTimeString: jest.fn(() => '2pm'),
-            },
-            location: 'Zoom',
-            showAs: ShowAs.OutOfOffice,
+        const status = getStatusForUserEvent(baseUserSettings, {
+          id: '1',
+          name: 'Quick Chat',
+          startTime: new Date(),
+          endTime: {
+            ...today,
+            getDate: jest.fn(() => today.getDate()),
+            toLocaleDateString: jest.fn(() => 'tomorrow'),
+            toLocaleTimeString: jest.fn(() => '2pm'),
           },
-          'UTC',
-        );
+          location: 'Zoom',
+          showAs: ShowAs.OutOfOffice,
+        });
 
         expect(status).toEqual({ text: 'OOO until 2pm', emoji: ':ooo:' });
       });
@@ -423,7 +394,6 @@ describe('getStatusForUserEvent', () => {
             location: 'Zoom',
             showAs: ShowAs.OutOfOffice,
           },
-          'UTC',
         );
 
         expect(status).toEqual({ text: 'OOO until tomorrow', emoji: ':ooo:' });
@@ -457,7 +427,6 @@ describe('getStatusForUserEvent', () => {
             location: 'Zoom',
             showAs: ShowAs.OutOfOffice,
           },
-          'UTC',
         );
 
         expect(status).toEqual({ text: 'OOO until 2pm', emoji: ':ooo:' });

--- a/src/utils/map-event-status.ts
+++ b/src/utils/map-event-status.ts
@@ -16,7 +16,7 @@ const getOOODateString = (endDateTime: Date | null, timeZone: string) => {
 export const getStatusForUserEvent = (
   settings: UserSettings,
   event: CalendarEvent | null,
-  userTimeZone: string,
+  userTimeZone: string = 'UTC',
 ): SlackStatus => {
   const defaultStatusByVisibility = {
     [ShowAs.Free]: settings.defaultStatus || { text: '', emoji: '' },


### PR DESCRIPTION
This fixes the way we determine our highest-priority event, as well as the way we determine timezone for OOO status strings. It now determines timezone by fetching the user's timezone from their Slack profile and setting it explicitly in the time formatter. Unfortunately, there is no local timezone information in the response from Microsoft Graph (even though the documentation *says* we should be able to use `originalStartTimeZone`).

It also fixes a bug in code where the date objects on our `CalendarEvent` class would actually use the machine timezone rather than UTC—the strings returned by Graph are in UTC but don't explicitly suffix the strings with a `Z`.