### PR TITLE
Look up room urls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ import {
   UserSettings,
 } from './services/dynamo';
 import { setUserStatus, setUserPresence, getUserByEmail, postMessage } from './services/slack';
+import { getUrlForRoom } from './services/rooms';
 import { Handler } from 'aws-lambda';
 import { InvocationRequest } from 'aws-sdk/clients/lambda';
 import { getStatusForUserEvent } from './utils/map-event-status';
@@ -44,7 +45,7 @@ const shouldUpdate = (e1: CalendarEvent | undefined, e2: CalendarEvent | null) =
   (!e1 && e2) || (e1 && !e2) || (e1 && e2 && e1.id !== e2.id);
 
 const sendUpcomingEventMessage = async (event: CalendarEvent | null, settings: UserSettings) => {
-  const url = getEventLocationUrl(event, settings);
+  const url = await getEventLocationUrl(event, settings);
   if (!event || !url) {
     return;
   }

--- a/src/services/rooms.ts
+++ b/src/services/rooms.ts
@@ -28,13 +28,15 @@ const hasNickname = (room: Room, query: string) => {
   );
 };
 
-const http = async <T>(url: string): Promise<T> => {
-  return fetch(url).then(response => {
-    if (!response.ok) {
-      throw new Error(response.statusText);
-    }
-    return response.json() as Promise<T>;
-  });
+const http = async <T>(url: string): Promise<Room[]> => {
+  return fetch(url)
+    .then(response => {
+      return response.json() as Promise<Room[]>;
+    })
+    .catch(e => {
+      console.log('Failed to fetch rooms data', e);
+      return [];
+    });
 };
 
 const fetchRoomsData = async (): Promise<Room[]> => {

--- a/src/services/rooms.ts
+++ b/src/services/rooms.ts
@@ -1,0 +1,61 @@
+import { roomsJsonUrl } from '../utils/urls';
+
+export type Capabilities = {
+  capacity: number;
+  bookable: boolean;
+  tv: boolean;
+  pc: boolean;
+  audio: boolean;
+};
+
+export type Room = {
+  id: string;
+  url: string;
+  nicknames: string[];
+  address: string;
+  office: string;
+  floor: number;
+  type: 'lounge' | 'phone-booth' | 'meeting' | 'mothers';
+  capabilities: Capabilities;
+};
+
+const roomData: Room[] = [];
+
+const hasNickname = (room: Room, query: string) => {
+  return !!(
+    (room && room.nicknames.length && room.nicknames.find(n => n.toLowerCase().indexOf(query) > -1)) ||
+    room.id.replace(/-/gi, ' ').indexOf(query) > -1
+  );
+};
+
+const http = async <T>(url: string): Promise<T> => {
+  return fetch(url).then(response => {
+    if (!response.ok) {
+      throw new Error(response.statusText);
+    }
+    return response.json() as Promise<T>;
+  });
+};
+
+const fetchRoomsData = async (): Promise<Room[]> => {
+  if (roomData.length === 0) {
+    const fetchedData = await http<Array<Room>>(roomsJsonUrl());
+    roomData.push(...fetchedData);
+  }
+
+  return roomData;
+};
+
+export const getUrlForRoom = async (query: string): Promise<string[]> => {
+  const data = await fetchRoomsData();
+
+  const foundRooms: string[] = [];
+  if (data && data.length) {
+    data.forEach(room => {
+      if (hasNickname(room, query)) {
+        foundRooms.push(room.url);
+      }
+    });
+  }
+  return foundRooms;
+};

--- a/src/utils/__tests__/eventHelper.tests.ts
+++ b/src/utils/__tests__/eventHelper.tests.ts
@@ -14,8 +14,8 @@ const baseEvent: CalendarEvent = {
 
 describe('getEventLocationUrl', () => {
   describe('Given a null event', () => {
-    test('Returns null', () => {
-      const url = getEventLocationUrl(null, baseUserSettings);
+    test('Returns null', async () => {
+      const url = await getEventLocationUrl(null, baseUserSettings);
 
       expect(url).toBeNull();
     });
@@ -24,73 +24,73 @@ describe('getEventLocationUrl', () => {
   describe('Url-only locations', () => {
     const testUrl = 'https://my.test.url';
 
-    test('Url-only returns the url', () => {
+    test('Url-only returns the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `${testUrl}`,
       };
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
-    test('Front-padded url returns just the url', () => {
+    test('Front-padded url returns just the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `   ${testUrl}`,
       };
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
-    test('Back-padded url returns just the url', () => {
+    test('Back-padded url returns just the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `${testUrl}     `,
       };
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
   });
 
   describe('Non-url locations', () => {
-    test('Gibberish returns null', () => {
+    test('Gibberish returns null', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: 'asdfqweoriu-123-wequio',
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBeNull();
     });
-    test('Names returns null', () => {
+    test('Names returns null', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: 'Jane Smith',
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBeNull();
     });
-    test('Meeting room names return null', () => {
+    test('Meeting room names return null', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: 'Michael Jordan',
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBeNull();
     });
-    test('Semicolon-separated names return null', () => {
+    test('Semicolon-separated names return null', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: 'Michael Jordan; Candace Parker; Bob Smith',
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBeNull();
     });
@@ -98,53 +98,53 @@ describe('getEventLocationUrl', () => {
 
   describe('Mixed locations', () => {
     const testUrl = 'https://my.test.url/stuff?123';
-    test('Url-first returns the url', () => {
+    test('Url-first returns the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `${testUrl} Michael Jordan`,
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
-    test('Semicolon-separated returns the url', () => {
+    test('Semicolon-separated returns the url', async() => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `${testUrl}; Michael Jordan`,
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
-    test('Url last returns the url', () => {
+    test('Url last returns the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `Michael Jordan; ${testUrl}`,
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
-    test('Url last with semicolon returns the url', () => {
+    test('Url last with semicolon returns the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `Michael Jordan; ${testUrl};`,
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });
-    test('Url middle returns the url', () => {
+    test('Url middle returns the url', async () => {
       const event: CalendarEvent = {
         ...baseEvent,
         location: `Michael Jordan; ${testUrl}; Scrum Masters;`,
       };
 
-      const url = getEventLocationUrl(event, baseUserSettings);
+      const url = await getEventLocationUrl(event, baseUserSettings);
 
       expect(url).toBe(testUrl);
     });

--- a/src/utils/urls.ts
+++ b/src/utils/urls.ts
@@ -4,3 +4,4 @@ export const createUserUrl = () => `${process.env.IS_OFFLINE ? config.hosts.dev 
 export const slackInstallUrl = () => `${process.env.IS_OFFLINE ? config.hosts.dev : config.hosts.prod}/slack/install`;
 export const authorizeMicrosoftGraphUrl = () =>
   `${process.env.IS_OFFLINE ? config.hosts.dev : config.hosts.prod}/authorize-microsoft-graph`;
+export const roomsJsonUrl = () => 'https://rooms.hudltools.com/static/data/rooms.json';


### PR DESCRIPTION
This should, theoretically, fetch data from rooms.hudltools.com, read it in, and match URL-less event locations to those rooms, and then return that url so it can be messaged to people with calendar events.

This helps remote employees who have to look up rooms every time when the majority of their team is meeting in-person.