### PR TITLE
Don't Update Status or Notify for Cancelled Events

### DIFF
--- a/src/services/calendar/calendar.ts
+++ b/src/services/calendar/calendar.ts
@@ -67,6 +67,7 @@ export const getEventsForUser = async (email: string, storedToken: Token): Promi
     const outlookEvents = await getAuthenticatedClient(email, storedToken)
       .api(`/users/${email}/calendarView?startDateTime=${startTime.toISOString()}&endDateTime=${endTime.toISOString()}`)
       .select('start,end,subject,body,showAs,location,sensitivity')
+      .filter('isCancelled eq false')
       .get();
 
     return outlookEvents.value.map((e: any) => {


### PR DESCRIPTION
I was recently sent a link to a cancelled meeting in Slack that I had not yet removed from my Outlook calendar, which seemed superfluous. The Microsoft Graph API exposes a flag indicating that the event has been cancelled and a filter function that can be used to filter out cancelled events from the query results.

This PR hasn't really been tested, other than testing the compiled API query string in the [Microsoft Graph Explorer](https://developer.microsoft.com/en-us/graph/graph-explorer). Since it is changing the query, it should probably be tested independently before deploying.