### PR TITLE
Use base-64 decode for config files in deploy action

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,12 +13,12 @@ jobs:
         uses: finnp/create-file-action@1.0.0
         env:
           FILE_NAME: config.ts
-          FILE_DATA: ${{ secrets.CONFIG_FILE_DATA }}
+          FILE_BASE64: ${{ secrets.CONFIG_FILE_DATA }}
       - name: create serverless config
         uses: finnp/create-file-action@1.0.0
         env:
           FILE_NAME: serverless-config.yml
-          FILE_DATA: ${{ secrets.SERVERLESS_CONFIG_FILE_DATA }}
+          FILE_BASE64: ${{ secrets.SERVERLESS_CONFIG_FILE_DATA }}
       - name: yarn
         uses: borales/actions-yarn@master
         with:


### PR DESCRIPTION
Because YML is a whitespace-important language, we need to preserve it in our secret config values. Base-64 is the easiest way to do this.