### PR TITLE
Don't use additional links copy in reminders when the only link is a location URL

### DIFF
--- a/src/utils/__tests__/eventHelper.tests.ts
+++ b/src/utils/__tests__/eventHelper.tests.ts
@@ -283,13 +283,19 @@ describe('getUpcomingEventMessage', () => {
       expect(message).toBeNull();
     });
   });
-  describe('With only a location URL', () => {
+  describe('With only a location URL in the location', () => {
     test('Returns a message with the URL', () => {
       const event = { ...baseEvent, location: 'https://my.test.url' };
       const message = getUpcomingEventMessage(event, baseUserSettings);
 
       expect(message).toBe(`Join *${event.name}* at: https://my.test.url`);
     });
+  });
+  describe('With only a location URL in the body', () => {
+    const event = { ...baseEvent, body: 'Join here: https://hudl.zoom.us/my/blahblah' };
+    const message = getUpcomingEventMessage(event, baseUserSettings);
+
+    expect(message).toBe(`Join *${event.name}* at: https://hudl.zoom.us/my/blahblah`);
   });
   describe('With a location and additional links', () => {
     test('Returns a message with the location and additional URLs', () => {

--- a/src/utils/eventHelper.ts
+++ b/src/utils/eventHelper.ts
@@ -48,13 +48,11 @@ export const getUpcomingEventMessage = (event: CalendarEvent | null, settings: U
   if (!locationUrl) return null;
 
   const additionalUrls = getAdditionalEventLinks(event);
-  let message = `Join *${event.name}* at: ${locationUrl}`;
+  const filteredUrls = additionalUrls.filter((url) => url.toLowerCase() !== locationUrl.toLowerCase());
 
-  if (additionalUrls.length) {
-    message = message.concat(
-      '. Here are some links I found in the event:',
-      ...additionalUrls.filter((url) => url.toLowerCase() !== locationUrl.toLowerCase()).map((url) => `\n• ${url}`),
-    );
+  let message = `Join *${event.name}* at: ${locationUrl}`;
+  if (filteredUrls.length) {
+    message = message.concat('. Here are some links I found in the event:', ...filteredUrls.map((url) => `\n• ${url}`));
   }
 
   return message;


### PR DESCRIPTION
The logic that decides when to include additional links in the reminder message was flawed because it checked the length of the `additionalLinks` array _before_ filtering out the location URL. This means that if the only link in the message is a location URL, it would result in messages like:

<img width="1111" alt="Screen Shot 2020-07-15 at 11 21 28 AM" src="https://user-images.githubusercontent.com/2313732/87570041-9f171580-c68d-11ea-8e7f-e40d36bd4319.png">

That claimed to have additional links, but provided none. This PR fixes that.