### PR TITLE
Update Zoom link copy to be more like a reminder and less like a command to immediately join

### DIFF
--- a/src/__tests__/updateOne.tests.ts
+++ b/src/__tests__/updateOne.tests.ts
@@ -248,7 +248,7 @@ describe('updateOne', () => {
             await updateOne(userWithCurrentEvent);
 
             expect(postMessageMock).toBeCalledWith(botToken, {
-              text: 'Join *meetings* at: https://my.test.url',
+              text: 'You have an upcoming meeting: *meetings* at https://my.test.url',
               channel: slackUser.id,
             });
           });
@@ -314,7 +314,7 @@ describe('updateOne', () => {
             await updateOne(overrideUser);
 
             expect(postMessageMock).toBeCalledWith(botToken, {
-              text: 'Join *anotha one* at: https://my.test.url/2',
+              text: 'You have an upcoming meeting: *anotha one* at https://my.test.url/2',
               channel: slackUser.id,
             });
           });

--- a/src/__tests__/updateOne.tests.ts
+++ b/src/__tests__/updateOne.tests.ts
@@ -302,7 +302,7 @@ describe('updateOne', () => {
         });
       });
     });
-    describe('with an override set', () => {
+    describe('with a valid override set', () => {
       const overrideUser = { ...userWithCurrentEvent, meetingReminderTimingOverride: 15 };
       describe('and an upcoming meeting with a location', () => {
         beforeEach(() => {
@@ -368,6 +368,14 @@ describe('updateOne', () => {
 
           expect(setLastReminderEventIdMock).not.toBeCalled();
         });
+      });
+    });
+    describe('with an override that matches the default value', () => {
+      test('does not make an additional request for user events', async () => {
+        getEventsForUserMock.mockResolvedValueOnce([oooEvent]);
+        await updateOne({ ...userWithCurrentEvent, meetingReminderTimingOverride: 1 });
+
+        expect(getEventsForUserMock).toBeCalledTimes(1);
       });
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -95,7 +95,7 @@ export const updateOne = async (us: UserSettings) => {
   const relevantEvent = getHighestPriorityEvent(userEvents);
 
   let reminderEvent = relevantEvent;
-  if (us.meetingReminderTimingOverride) {
+  if (us.meetingReminderTimingOverride && us.meetingReminderTimingOverride > 1) {
     const upcomingEvents = await getEventsForUser(us.email, us.calendarStoredToken, us.meetingReminderTimingOverride);
     reminderEvent = getHighestPriorityEvent(upcomingEvents || []);
   }

--- a/src/utils/__tests__/eventHelper.tests.ts
+++ b/src/utils/__tests__/eventHelper.tests.ts
@@ -288,14 +288,14 @@ describe('getUpcomingEventMessage', () => {
       const event = { ...baseEvent, location: 'https://my.test.url' };
       const message = getUpcomingEventMessage(event, baseUserSettings);
 
-      expect(message).toBe(`Join *${event.name}* at: https://my.test.url`);
+      expect(message).toBe(`You have an upcoming meeting: *${event.name}* at https://my.test.url`);
     });
   });
   describe('With only a location URL in the body', () => {
     const event = { ...baseEvent, body: 'Join here: https://hudl.zoom.us/my/blahblah' };
     const message = getUpcomingEventMessage(event, baseUserSettings);
 
-    expect(message).toBe(`Join *${event.name}* at: https://hudl.zoom.us/my/blahblah`);
+    expect(message).toBe(`You have an upcoming meeting: *${event.name}* at https://hudl.zoom.us/my/blahblah`);
   });
   describe('With a location and additional links', () => {
     test('Returns a message with the location and additional URLs', () => {
@@ -307,7 +307,7 @@ describe('getUpcomingEventMessage', () => {
       const message = getUpcomingEventMessage(event, baseUserSettings);
 
       expect(message).toBe(
-        `Join *${event.name}* at: https://my.test.url. Here are some links I found in the event:
+        `You have an upcoming meeting: *${event.name}* at https://my.test.url. Here are some links I found in the event:
 • https://agenda.url
 • https://cool.url`,
       );
@@ -321,7 +321,7 @@ describe('getUpcomingEventMessage', () => {
       const message = getUpcomingEventMessage(event, baseUserSettings);
 
       expect(message).toBe(
-        `Join *${event.name}* at: https://my.test.url. Here are some links I found in the event:
+        `You have an upcoming meeting: *${event.name}* at https://my.test.url. Here are some links I found in the event:
 • https://agenda.url`,
       );
     });

--- a/src/utils/eventHelper.ts
+++ b/src/utils/eventHelper.ts
@@ -50,7 +50,7 @@ export const getUpcomingEventMessage = (event: CalendarEvent | null, settings: U
   const additionalUrls = getAdditionalEventLinks(event);
   const filteredUrls = additionalUrls.filter((url) => url.toLowerCase() !== locationUrl.toLowerCase());
 
-  let message = `Join *${event.name}* at: ${locationUrl}`;
+  let message = `You have an upcoming meeting: *${event.name}* at ${locationUrl}`;
   if (filteredUrls.length) {
     message = message.concat('. Here are some links I found in the event:', ...filteredUrls.map((url) => `\n• ${url}`));
   }


### PR DESCRIPTION
Changes the copy in the Slackbot message with Zoom links to be: "You have an upcoming meeting: **meeting name** at https://some.url." This copy better covers both imminent and eventual meetings when the user has a timing override set.

This PR also ensures that we only make a second request for user events when the user's override is > 1 (the default value).