### PR TITLE
Allow users to use `settings show` to display current settings; display settings after update

### DIFF
--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -9,7 +9,7 @@ import {
   removeDefaultStatus,
 } from './services/dynamo';
 import { slackInstallUrl } from './utils/urls';
-import { handleUpdateSettings } from './slackbot/settings';
+import { handleSettings } from './slackbot/settings';
 
 const MILLIS_IN_SEC = 1000;
 const FIVE_MIN_IN_SEC = 300;
@@ -223,7 +223,7 @@ const commandHandlerMap: {
   remove: handleRemove,
   'set-default': handleSetDefault,
   'remove-default': handleRemoveDefault,
-  settings: handleUpdateSettings,
+  settings: handleSettings,
 };
 
 const handleSlackEventCallback = async ({

--- a/src/slackbot/__tests__/settings.tests.ts
+++ b/src/slackbot/__tests__/settings.tests.ts
@@ -84,10 +84,17 @@ describe('handleSettings', () => {
     });
   });
   describe('With zoom-links argument', () => {
+    beforeEach(() => {
+      setZoomLinksMock.mockResolvedValueOnce({ ...userSettings, zoomLinksDisabled: true });
+    });
     test('Returns settings updated message', async () => {
-      const message = await handleSettings(userSettings, ['zoom-links=true']);
+      const message = await handleSettings(userSettings, ['zoom-links=false']);
 
-      expect(message).toBe('Your settings have been updated.');
+      expect(message).toBe(
+        `Your settings have been updated:
+• \`zoom-links\`: \`false\`
+• \`reminder-timing\`: \`1\``,
+      );
     });
     test('Updates the zoom-links setting in DynamoDB', async () => {
       await handleSettings(userSettings, ['zoom-links=true']);
@@ -96,10 +103,17 @@ describe('handleSettings', () => {
     });
   });
   describe('With reminder-timing argument', () => {
+    beforeEach(() => {
+      meetingReminderMock.mockResolvedValueOnce({ ...userSettings, meetingReminderTimingOverride: 15 });
+    });
     test('Returns settings updated message', async () => {
       const message = await handleSettings(userSettings, ['reminder-timing=15']);
 
-      expect(message).toBe('Your settings have been updated.');
+      expect(message).toBe(
+        `Your settings have been updated:
+• \`zoom-links\`: \`true\`
+• \`reminder-timing\`: \`15\``,
+      );
     });
     test('Updates the reminder-timing setting in DynamoDB', async () => {
       await handleSettings(userSettings, ['reminder-timing=15']);
@@ -108,10 +122,22 @@ describe('handleSettings', () => {
     });
   });
   describe('With multiple arguments', () => {
+    beforeEach(() => {
+      setZoomLinksMock.mockResolvedValueOnce({ ...userSettings, zoomLinksDisabled: true });
+      meetingReminderMock.mockResolvedValueOnce({
+        ...userSettings,
+        zoomLinksDisabled: true,
+        meetingReminderTimingOverride: 15,
+      });
+    });
     test('Returns settings updated message', async () => {
-      const message = await handleSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
+      const message = await handleSettings(userSettings, ['zoom-links=false', 'reminder-timing=15']);
 
-      expect(message).toBe('Your settings have been updated.');
+      expect(message).toBe(
+        `Your settings have been updated:
+• \`zoom-links\`: \`false\`
+• \`reminder-timing\`: \`15\``,
+      );
     });
     test('Updates the zoom-links setting in DynamoDB', async () => {
       await handleSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);

--- a/src/slackbot/__tests__/settings.tests.ts
+++ b/src/slackbot/__tests__/settings.tests.ts
@@ -1,4 +1,4 @@
-import { handleUpdateSettings } from '../settings';
+import { handleSettings } from '../settings';
 import { setZoomLinksDisabled, setMeetingReminderTimingOverride } from '../../services/dynamo';
 
 jest.mock('../../services/dynamo');
@@ -13,10 +13,10 @@ const userSettings = {
   email: 'blah@blah.com',
 };
 
-describe('handleUpdateSettings', () => {
+describe('handleSettings', () => {
   describe('With no arguments provided', () => {
     test('Returns a message requesting at least one argument', async () => {
-      const message = await handleUpdateSettings(userSettings, []);
+      const message = await handleSettings(userSettings, []);
 
       expect(message).toBe(
         'You must provide at least one argument. See the wiki for more information: https://github.com/hudl/CalendarToSlack/wiki',
@@ -25,56 +25,101 @@ describe('handleUpdateSettings', () => {
   });
   describe('With unsupported arguments', () => {
     test('Returns a message requesting a supported argument', async () => {
-      const message = await handleUpdateSettings(userSettings, ['my-command = hello']);
+      const message = await handleSettings(userSettings, ['my-command = hello']);
 
       expect(message).toBe(
         'No supported arguments given. See the wiki for more information: https://github.com/hudl/CalendarToSlack/wiki',
       );
     });
     test('Does not update any settings in DynamoDB', async () => {
-      await handleUpdateSettings(userSettings, ['my-command = hello']);
+      await handleSettings(userSettings, ['my-command = hello']);
 
       expect(meetingReminderMock).not.toBeCalled();
       expect(setZoomLinksMock).not.toBeCalled();
     });
   });
+  describe('With show argument for user with no settings set', () => {
+    test('Returns message displaying defaults for all settings', async () => {
+      const message = await handleSettings(userSettings, ['show']);
+
+      expect(message).toBe(`Here are your current settings:
+• \`zoom-links\`: \`true\`
+• \`reminder-timing\`: \`1\``);
+    });
+  });
+  describe('With show argument for user with zoom-links set', () => {
+    test('Returns message displaying current value for zoom-links', async () => {
+      const message = await handleSettings({ ...userSettings, zoomLinksDisabled: true }, ['show']);
+
+      expect(message).toBe(
+        `Here are your current settings:
+• \`zoom-links\`: \`false\`
+• \`reminder-timing\`: \`1\``,
+      );
+    });
+  });
+  describe('With show argument for user with reminder-timing set', () => {
+    test('Returns message displaying current value for reminder-timing', async () => {
+      const message = await handleSettings({ ...userSettings, meetingReminderTimingOverride: 15 }, ['show']);
+
+      expect(message).toBe(
+        `Here are your current settings:
+• \`zoom-links\`: \`true\`
+• \`reminder-timing\`: \`15\``,
+      );
+    });
+  });
+  describe('With show argument for user with all settings set', () => {
+    test('Returns message displaying current value for all settings', async () => {
+      const message = await handleSettings(
+        { ...userSettings, zoomLinksDisabled: true, meetingReminderTimingOverride: 15 },
+        ['show'],
+      );
+
+      expect(message).toBe(
+        `Here are your current settings:
+• \`zoom-links\`: \`false\`
+• \`reminder-timing\`: \`15\``,
+      );
+    });
+  });
   describe('With zoom-links argument', () => {
     test('Returns settings updated message', async () => {
-      const message = await handleUpdateSettings(userSettings, ['zoom-links=true']);
+      const message = await handleSettings(userSettings, ['zoom-links=true']);
 
       expect(message).toBe('Your settings have been updated.');
     });
     test('Updates the zoom-links setting in DynamoDB', async () => {
-      await handleUpdateSettings(userSettings, ['zoom-links=true']);
+      await handleSettings(userSettings, ['zoom-links=true']);
 
       expect(setZoomLinksMock).toBeCalledWith(userSettings.email, false);
     });
   });
   describe('With reminder-timing argument', () => {
     test('Returns settings updated message', async () => {
-      const message = await handleUpdateSettings(userSettings, ['reminder-timing=15']);
+      const message = await handleSettings(userSettings, ['reminder-timing=15']);
 
       expect(message).toBe('Your settings have been updated.');
     });
     test('Updates the reminder-timing setting in DynamoDB', async () => {
-      await handleUpdateSettings(userSettings, ['reminder-timing=15']);
+      await handleSettings(userSettings, ['reminder-timing=15']);
 
       expect(meetingReminderMock).toBeCalledWith(userSettings.email, 15);
     });
   });
   describe('With multiple arguments', () => {
     test('Returns settings updated message', async () => {
-      const message = await handleUpdateSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
+      const message = await handleSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
 
       expect(message).toBe('Your settings have been updated.');
     });
     test('Updates the zoom-links setting in DynamoDB', async () => {
-      await handleUpdateSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
+      await handleSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
 
       expect(setZoomLinksMock).toBeCalledWith(userSettings.email, false);
     });
     test('Updates the reminder-timing setting in DynamoDB', async () => {
-      await handleUpdateSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
+      await handleSettings(userSettings, ['zoom-links=true', 'reminder-timing=15']);
 
       expect(meetingReminderMock).toBeCalledWith(userSettings.email, 15);
     });

--- a/src/slackbot/settings.ts
+++ b/src/slackbot/settings.ts
@@ -62,6 +62,6 @@ export const handleSettings = async (userSettings: UserSettings, argList: string
   }
 
   return newSettings
-    ? 'Your settings have been updated.'
+    ? `Your settings have been updated:\n${stringifySettings(newSettings)}`
     : 'No supported arguments given. See the wiki for more information: https://github.com/hudl/CalendarToSlack/wiki';
 };

--- a/src/slackbot/settings.ts
+++ b/src/slackbot/settings.ts
@@ -2,18 +2,19 @@ import { UserSettings, setZoomLinksDisabled, setMeetingReminderTimingOverride } 
 
 type SettingsCommandArguments = {
   zoomLinksEnabled?: boolean;
-  meetingReminderOverride?: number;
+  meetingReminderTimingOverride?: number;
 };
 
-enum SettingsArguments {
+enum SettingsCommandArgumentKeys {
+  Show = 'show',
   ZoomLinks = 'zoom-links',
   ReminderTiming = 'reminder-timing',
 }
 
 const constructSettingsCommandArgs = (argList: string[]): SettingsCommandArguments => {
   const args: { [key: string]: string } = {
-    [SettingsArguments.ZoomLinks]: '',
-    [SettingsArguments.ReminderTiming]: '',
+    [SettingsCommandArgumentKeys.ZoomLinks]: '',
+    [SettingsCommandArgumentKeys.ReminderTiming]: '',
   };
 
   for (let arg of argList) {
@@ -23,34 +24,44 @@ const constructSettingsCommandArgs = (argList: string[]): SettingsCommandArgumen
     }
   }
 
-  const zoomLinksArg = args[SettingsArguments.ZoomLinks];
-  const reminderTimingArg = args[SettingsArguments.ReminderTiming];
+  const zoomLinksArg = args[SettingsCommandArgumentKeys.ZoomLinks];
+  const reminderTimingArg = args[SettingsCommandArgumentKeys.ReminderTiming];
 
   return {
     zoomLinksEnabled: zoomLinksArg.length ? zoomLinksArg.toLowerCase() === 'true' : undefined,
-    meetingReminderOverride: reminderTimingArg.length ? Number(reminderTimingArg) : undefined,
+    meetingReminderTimingOverride: reminderTimingArg.length ? Number(reminderTimingArg) : undefined,
   };
 };
 
-export const handleUpdateSettings = async (userSettings: UserSettings, argList: string[]): Promise<string> => {
+const stringifySettings = ({ zoomLinksDisabled, meetingReminderTimingOverride }: UserSettings) => {
+  const zoomLinksString = `• \`${SettingsCommandArgumentKeys.ZoomLinks}\`: \`${!zoomLinksDisabled}\``;
+  const reminderTimingString = `• \`${SettingsCommandArgumentKeys.ReminderTiming}\`: \`${
+    meetingReminderTimingOverride || 1
+  }\``;
+
+  return `${zoomLinksString}\n${reminderTimingString}`;
+};
+
+export const handleSettings = async (userSettings: UserSettings, argList: string[]): Promise<string> => {
   if (!argList.length) {
     return 'You must provide at least one argument. See the wiki for more information: https://github.com/hudl/CalendarToSlack/wiki';
   }
 
+  if (argList[0].toLowerCase() === SettingsCommandArgumentKeys.Show) {
+    return `Here are your current settings:\n${stringifySettings(userSettings)}`;
+  }
+
   const args = constructSettingsCommandArgs(argList);
 
-  let settingsUpdated = false;
+  let newSettings;
   if (args.zoomLinksEnabled !== undefined) {
-    await setZoomLinksDisabled(userSettings.email, !args.zoomLinksEnabled);
-    settingsUpdated = true;
+    newSettings = await setZoomLinksDisabled(userSettings.email, !args.zoomLinksEnabled);
   }
-  if (args.meetingReminderOverride !== undefined) {
-    await setMeetingReminderTimingOverride(userSettings.email, args.meetingReminderOverride);
-    settingsUpdated = true;
+  if (args.meetingReminderTimingOverride !== undefined) {
+    newSettings = await setMeetingReminderTimingOverride(userSettings.email, args.meetingReminderTimingOverride);
   }
 
-  // TODO: Once more settings are present, change this to echo their settings
-  return settingsUpdated
+  return newSettings
     ? 'Your settings have been updated.'
     : 'No supported arguments given. See the wiki for more information: https://github.com/hudl/CalendarToSlack/wiki';
 };


### PR DESCRIPTION
Implements a basic `settings show` command that will display the current values of your settings (`zoom-links` and `reminder-timing`). If you haven't explicitly configured a setting, it'll display the setting's default value. The current values of your settings will also be returned after updating any setting.