### PR TITLE
Properly handle failure to get a user by email from the Slack API

### DIFF
--- a/src/services/__tests__/slack.tests.ts
+++ b/src/services/__tests__/slack.tests.ts
@@ -1,0 +1,65 @@
+import { getUserByEmail } from '../slack';
+import { WebClient, WebAPIPlatformError } from '@slack/web-api';
+
+const mockLookupByEmail = jest.fn();
+jest.mock('@slack/web-api', () => {
+  return {
+    WebClient: jest.fn().mockImplementation(() => {
+      return {
+        users: {
+          lookupByEmail: mockLookupByEmail,
+        },
+      };
+    }),
+  };
+});
+
+describe('getUserByEmail', () => {
+  describe('with empty token supplied', () => {
+    test('returns undefined', async () => {
+      const user = await getUserByEmail('', 'test@test.com');
+
+      expect(user).toBeUndefined();
+    });
+  });
+  describe('with empty email supplied', () => {
+    test('returns undefined', async () => {
+      const user = await getUserByEmail('token', '');
+
+      expect(user).toBeUndefined();
+    });
+  });
+  describe('with valid token and email supplied', () => {
+    describe('and an OK response from the API', () => {
+      test('returns the user', async () => {
+        const expectedUser = { name: 'hello' };
+        mockLookupByEmail.mockResolvedValueOnce({ ok: true, user: expectedUser });
+
+        const user = await getUserByEmail('token', 'test@test.com');
+        expect(user).toBe(expectedUser);
+      });
+    });
+    describe('and a users_not_found error from the API', () => {
+      test('returns undefined', async () => {
+        mockLookupByEmail.mockRejectedValueOnce({ ok: false, data: { error: 'users_not_found' } });
+
+        const user = await getUserByEmail('token', 'test@test.com');
+        expect(user).toBeUndefined();
+      });
+    });
+    describe('and a different error from the API', () => {
+      test('throws an error', async () => {
+        expect.assertions(1);
+
+        const expectedError = { ok: false, data: { error: 'another_error' } };
+        mockLookupByEmail.mockRejectedValueOnce({ ok: false, data: { error: 'another_error' } });
+
+        try {
+          await getUserByEmail('token', 'test@test.com');
+        } catch (e) {
+          expect(e).toEqual(expectedError);
+        }
+      });
+    });
+  });
+});

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -76,14 +76,21 @@ export const getUserInfo = async (token: string, slackUserId: string): Promise<S
 };
 
 export const getUserByEmail = async (token: string, email: string): Promise<SlackUser | undefined> => {
-  if (!token) return;
+  if (!token || !email) return;
 
   const slackClient = new WebClient(token);
-  const user = (await slackClient.users.lookupByEmail({ token, email })).user as SlackUser;
 
-  if (!user) console.warn(`Could not find Slack user for email: ${email}`);
+  try {
+    return (await slackClient.users.lookupByEmail({ token, email })).user as SlackUser;
+  } catch (e) {
+    if (e.data.error === 'users_not_found') {
+      console.warn(`Could not find Slack user for email: ${email}`);
+      return;
+    }
 
-  return user;
+    console.error(`Error getting Slack user for email: ${email}`, e);
+    throw e;
+  }
 };
 
 export const postMessage = async (token: string, params: ChatPostMessageArguments): Promise<boolean> => {


### PR DESCRIPTION
Ever since #25 was merged, we've been making an API call to Slack on every user update in order to fetch their timezone. Unfortunately, this API call fails by throwing an exception from the SDK, which our code wasn't handling correctly. This correctly try/catches that API call and adds some more logging so we can understand which emails we're failing to get Slack users for.