### PR TITLE
Add isomorphic-fetch polyfill

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@microsoft/microsoft-graph-client": "^2.2.1",
     "@slack/web-api": "^6.2.4",
     "aws-sdk": "^2.493.0",
+    "isomorphic-fetch": "^3.0.0",
     "simple-oauth2": "^2.2.1"
   }
 }

--- a/src/services/calendar/graphApiAuthenticationProvider.ts
+++ b/src/services/calendar/graphApiAuthenticationProvider.ts
@@ -1,3 +1,4 @@
+import 'isomorphic-fetch';
 import { AuthenticationProvider } from '@microsoft/microsoft-graph-client';
 import oauth2, { OAuthClient, Token } from 'simple-oauth2';
 import { storeCalendarAuthenticationToken } from '../dynamo';

--- a/src/services/calendar/index.ts
+++ b/src/services/calendar/index.ts
@@ -1,3 +1,4 @@
+import 'isomorphic-fetch';
 import { Client, ClientOptions } from '@microsoft/microsoft-graph-client';
 import { GraphApiAuthenticationProvider } from './graphApiAuthenticationProvider';
 import { Token } from 'simple-oauth2';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4596,6 +4596,14 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isomorphic-fetch@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-3.0.0.tgz#0267b005049046d2421207215d45d6a262b8b8b4"
+  integrity sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA==
+  dependencies:
+    node-fetch "^2.6.1"
+    whatwg-fetch "^3.4.1"
+
 isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
@@ -8146,6 +8154,11 @@ whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
+
+whatwg-fetch@^3.4.1:
+  version "3.6.2"
+  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.6.2.tgz#dced24f37f2624ed0281725d51d0e2e3fe677f8c"
+  integrity sha512-bJlen0FcuU/0EMLrdbJ7zOnW6ITZLrZMIarMUVmdKtsGvZna8vxKYaexICWPfZ8qwf9fzNq+UEIZrnSaApt6RA==
 
 whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
This will hopefully stop these errors:

```
2021-08-22T19:36:47.272Z	ccaa2b83-cbb0-4e63-844e-a515284ace06	ERROR	PolyFillNotAvailable: Library cannot function without fetch. So, please provide polyfill for it.
    at Object.exports.validatePolyFilling (/var/task/node_modules/@microsoft/microsoft-graph-client/lib/src/ValidatePolyFilling.js:27:21)
    at new Client (/var/task/node_modules/@microsoft/microsoft-graph-client/lib/src/Client.js:36:35)
    at Function.Client.initWithMiddleware (/var/task/node_modules/@microsoft/microsoft-graph-client/lib/src/Client.js:92:20)
    at getAuthenticatedClient (/var/task/src/services/calendar/index.js:37:44)
    at Object.exports.getEventsForUser (/var/task/src/services/calendar/index.js:52:37)
    at exports.updateOne (/var/task/src/index.js:61:41)
    at Array.map (<anonymous>)
    at Runtime.exports.updateBatch [as handler] (/var/task/src/index.js:58:36)
    at processTicksAndRejections (internal/process/task_queues.js:95:5)
```