### PR TITLE
Allow users to snooze Cal2Slack

### DIFF
--- a/src/__tests__/updateOne.tests.ts
+++ b/src/__tests__/updateOne.tests.ts
@@ -63,6 +63,15 @@ const slackUser: SlackUser = {
 getUserByEmailMock.mockResolvedValue(slackUser);
 
 describe('updateOne', () => {
+  test('skips updates for snoozed users', () => {
+    updateOne({ ...baseUserSettings, snoozed: true });
+
+    expect(setUserStatusMock).not.toBeCalled();
+    expect(setUserPresenceMock).not.toBeCalled();
+    expect(upsertCurrentEventMock).not.toBeCalled();
+    expect(postMessageMock).not.toBeCalled();
+  });
+
   describe('updating Slack status', () => {
     describe('with no events found for the next minute', () => {
       beforeEach(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,6 +75,7 @@ export const update: Handler = async () => {
   };
 
   const userSettings = await getAllUserSettings();
+  
   for (var i = 0; i < userSettings.length; i += batchSize) {
     const batch = userSettings.slice(i, i + batchSize).map((us) => us.email);
 
@@ -89,6 +90,8 @@ export const updateBatch: Handler = async (event: any) => {
 };
 
 export const updateOne = async (us: UserSettings) => {
+  if (us.snoozed) return;
+
   const userEvents = await getEventsForUser(us.email, us.calendarStoredToken);
   if (!userEvents) return;
 

--- a/src/services/dynamo.ts
+++ b/src/services/dynamo.ts
@@ -19,6 +19,7 @@ export type UserSettings = {
   zoomLinksDisabled?: boolean;
   meetingReminderTimingOverride?: number;
   lastReminderEventId?: string;
+  snoozed?: boolean;
 };
 
 const toDynamoStatus = (status: SlackStatus) => ({
@@ -372,6 +373,34 @@ export const setLastReminderEventId = async (email: string, lastReminderEventId:
         UpdateExpression: 'set lastReminderEventId = :id',
         ExpressionAttributeValues: {
           ':id': lastReminderEventId,
+        },
+        ReturnValues: 'ALL_NEW',
+      },
+      (err, data) => {
+        if (err) {
+          reject(err.message);
+          return;
+        }
+
+        resolve(data.Attributes as UserSettings);
+      },
+    ),
+  );
+};
+
+export const setSnoozed = async (email: string, snoozed: boolean): Promise<UserSettings> => {
+  const dynamoDb = new AWS.DynamoDB.DocumentClient();
+
+  return new Promise((resolve, reject) =>
+    dynamoDb.update(
+      {
+        TableName: config.dynamoDb.tableName,
+        Key: {
+          email,
+        },
+        UpdateExpression: 'set snoozed = :s',
+        ExpressionAttributeValues: {
+          ':s': snoozed,
         },
         ReturnValues: 'ALL_NEW',
       },

--- a/src/utils/__tests__/mapEventStatus.tests.ts
+++ b/src/utils/__tests__/mapEventStatus.tests.ts
@@ -368,7 +368,7 @@ describe('getStatusForUserEvent', () => {
           endTime: {
             ...today,
             getDate: jest.fn(() => today.getDate()),
-            toLocaleDateString: jest.fn(() => 'tomorrow'),
+            toLocaleDateString: jest.fn((...args) => today.toLocaleDateString(...args)),
             toLocaleTimeString: jest.fn(() => '2pm'),
           },
           location: 'Zoom',
@@ -437,7 +437,7 @@ describe('getStatusForUserEvent', () => {
             endTime: {
               ...today,
               getDate: jest.fn(() => today.getDate()),
-              toLocaleDateString: jest.fn(() => 'tomorrow'),
+              toLocaleDateString: jest.fn((...args) => today.toLocaleDateString(...args)),
               toLocaleTimeString: jest.fn(() => '2pm'),
             },
             location: 'Zoom',

--- a/src/utils/mapEventStatus.ts
+++ b/src/utils/mapEventStatus.ts
@@ -7,8 +7,11 @@ const getOOODateString = (endDateTime: Date | null, timeZone: string) => {
 
   const today = new Date();
 
+  const endDateString = endDateTime.toLocaleDateString('en-us', { day: '2-digit', month: '2-digit', year: 'numeric', timeZone });
+  const todayDateString = today.toLocaleDateString('en-us', { day: '2-digit', month: '2-digit', year: 'numeric', timeZone });
+
   // TODO: We have no good way of knowing an intl locale at the moment—is this something we need to supply via Office365 or store in user settings?
-  return endDateTime.getDate() === today.getDate()
+  return endDateString === todayDateString
     ? endDateTime.toLocaleTimeString('en-us', { hour: 'numeric', minute: '2-digit', second: '2-digit', timeZone })
     : endDateTime.toLocaleDateString('en-us', { weekday: 'long', day: 'numeric', month: 'long', timeZone });
 };


### PR DESCRIPTION
Adds a new settings option, `snoozed`, and allows users to update it by sending Super Cal2Slack the command `settings snoozed=[true|false]`. Cal2Slack will then skip updates until the user changes the setting back to `false`.