### PR TITLE
Better slack error handling

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,10 +21,6 @@ import { getSlackSecretWithKey } from './utils/secrets';
 import { authorizeMicrosoftGraphUrl, createUserUrl } from './utils/urls';
 import { getUpcomingEventMessage } from './utils/eventHelper';
 
-type GetProfileResult = {
-  email: string;
-};
-
 const getHighestPriorityEvent = (events: CalendarEvent[]) =>
   events.length
     ? events.sort(


### PR DESCRIPTION
Another small PR to just add some better error handling and logging, this time around Slack. From the following error from the create user endpoint, there's at least an error creating new DynamoDb records. I'd expect errors with the other update scenarios at this point but that's not happening. #85 follows up to update the entire DynamoDb client with the latest SDK.

```
2023-10-10T18:02:51.151Z	a8b718ef-c95b-40c2-b656-7fd53441340e	ERROR	Invoke Error 	{
    "errorType": "TypeError",
    "errorMessage": "Cannot read property 'code' of null",
    "stack": [
        "TypeError: Cannot read property 'code' of null",
        "    at Runtime.exports.createUser [as handler] (/var/task/src/index.js:109:46)",
        "    at Runtime.handleOnceNonStreaming (/var/runtime/Runtime.js:74:25)"
    ]
}

```