### PR TITLE
Request access to email address (under new scope now)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -192,25 +192,25 @@ export const createUser: Handler = async (event: any) => {
   const tokenStr: string = accessToken.token.access_token;
 
   const slackClient = new WebClient(tokenStr);
-  const profileResult = await slackClient.users.profile.get();
+  const userInfo = await slackClient.users.info();
 
-  if (profileResult.error) {
-    console.error('Error getting profile from Slack', profileResult.error);
+  if (userInfo.error) {
+    console.error('Error getting profile from Slack', userInfo.error);
     return {
       statusCode: 400,
       body: 'Error getting profile from Slack.',
     };
   }
 
-  if (!profileResult.profile || !profileResult.profile.email) {
-    console.error('No email returned from Slack', profileResult);
+  if (!userInfo.user || !userInfo.user.profile || !userInfo.user.profile.email) {
+    console.error('No email returned from Slack', userInfo);
     return {
       statusCode: 400,
       body: 'No email returned from Slack.',
     };
   }
 
-  const { email } = profileResult.profile;
+  const { email } = userInfo.user.profile;
 
   await upsertSlackToken(email, tokenStr);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export const slackInstall: Handler = async () => ({
     Location: `https://slack.com/oauth/authorize?client_id=${
       config.slack.clientId
     }&redirect_uri=${createUserUrl()}&scope=${encodeURIComponent(
-      'users.profile:read,users.profile:write,users:write,users:read.email',
+      'users.profile:read,users.profile:write,users:write,users:read,users:read.email',
     )}`,
   },
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -155,7 +155,7 @@ export const slackInstall: Handler = async () => ({
     Location: `https://slack.com/oauth/authorize?client_id=${
       config.slack.clientId
     }&redirect_uri=${createUserUrl()}&scope=${encodeURIComponent(
-      'users.profile:read,users.profile:write,users:write',
+      'users.profile:read,users.profile:write,users:write,users:read.email',
     )}`,
   },
 });


### PR DESCRIPTION
With new logging added during the `/create-user` flow, I noticed that to `email` field is returned on the Slack user's profile after authenticating with the bot. The documentation indicates that access to that field is now gated under a new scope that must be requested. This PR also updates to the `users.info` API over the `users.profile.get` API per the recommendation in the docs and S/O posts. The change is relatively simple given the strongly typed Slack client.

https://api.slack.com/scopes/users:read.email