### PR TITLE
Add expiration to SlackStatus allowing users to see when you get out of your current calendar event

### DIFF
--- a/src/__tests__/updateOne.tests.ts
+++ b/src/__tests__/updateOne.tests.ts
@@ -143,6 +143,7 @@ describe('updateOne', () => {
           expect(setUserStatusMock).toHaveBeenCalledWith(userWithCurrentEvent.email, userWithCurrentEvent.slackToken, {
             text: 'OOO until Saturday, January 4',
             emoji: ':ooo:',
+            expiration: oooEvent.endTime.valueOf()
           });
           expect(setUserPresenceMock).toHaveBeenCalledWith(
             userWithCurrentEvent.email,
@@ -198,6 +199,7 @@ describe('updateOne', () => {
           expect(setUserStatusMock).toHaveBeenCalledWith(userWithCurrentEvent.email, userWithCurrentEvent.slackToken, {
             text: 'OOO until Saturday, January 4',
             emoji: ':ooo:',
+            expiration: oooEvent.endTime.valueOf()
           });
           expect(setUserPresenceMock).toHaveBeenCalledWith(
             userWithCurrentEvent.email,
@@ -231,6 +233,7 @@ describe('updateOne', () => {
           expect(setUserStatusMock).toHaveBeenCalledWith(userWithCurrentEvent.email, userWithCurrentEvent.slackToken, {
             text: 'Away',
             emoji: ':spiral_calendar_pad:',
+            expiration: busyEvent.endTime.valueOf()
           });
           expect(setUserPresenceMock).toHaveBeenCalledWith(
             userWithCurrentEvent.email,

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -61,12 +61,14 @@ export const setUserStatus = async (email: string, token: string | undefined, st
 
   const slackClient = new WebClient(token);
 
+  const expiration_seconds = Math.floor((status?.expiration || 0) / 1000);
+
   try {
     await slackClient.users.profile.set({
       profile: {
         status_text: status?.text || '',
         status_emoji: status?.emoji || '',
-        status_expiration: status?.expiration || 0,
+        status_expiration: expiration_seconds,
       },
     });
   } catch (error) {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -6,6 +6,7 @@ import { slackInstallUrl } from '../utils/urls';
 export type SlackStatus = {
   text?: string;
   emoji?: string;
+  expiration?: number;
 };
 
 export type SlackUserProfile = {
@@ -56,7 +57,7 @@ export const setUserPresence = async (email: string, token: string | undefined, 
 export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
 
-  console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email}`);
+  console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`);
 
   const slackClient = new WebClient(token);
 
@@ -65,6 +66,7 @@ export const setUserStatus = async (email: string, token: string | undefined, st
       profile: {
         status_text: status?.text || '',
         status_emoji: status?.emoji || '',
+        status_expiration: status?.expiration || 0,
       },
     });
   } catch (error) {

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -207,7 +207,7 @@ const handleSetDefault = async (userSettings: UserSettings, argList: string[]): 
 
 const handleRemoveDefault = async (userSettings: UserSettings): Promise<string> => {
   const slackPromise = !userSettings.currentEvent
-    ? setUserStatus(userSettings.email, userSettings.slackToken, { text: '', emoji: '' })
+    ? setUserStatus(userSettings.email, userSettings.slackToken, { text: '', emoji: '', expiration: 0 })
     : Promise.resolve();
 
   await Promise.all([removeDefaultStatus(userSettings.email), slackPromise]);

--- a/src/utils/__tests__/mapEventStatus.tests.ts
+++ b/src/utils/__tests__/mapEventStatus.tests.ts
@@ -4,6 +4,8 @@ import { ShowAs } from '../../services/calendar';
 const baseUserSettings = { email: 'test@email.com', slackToken: 'abc' };
 
 describe('getStatusForUserEvent', () => {
+  const date = new Date();
+
   describe('Given a null event', () => {
     test('Returns an empty status by default', () => {
       const status = getStatusForUserEvent(baseUserSettings, null);
@@ -37,8 +39,8 @@ describe('getStatusForUserEvent', () => {
         id: '1',
         name: 'Quick Chat',
         body: '',
-        startTime: new Date(),
-        endTime: new Date(),
+        startTime: date,
+        endTime: date,
         location: 'Zoom',
         showAs: ShowAs.Busy,
       },
@@ -47,6 +49,7 @@ describe('getStatusForUserEvent', () => {
     expect(status).toEqual({
       text: 'Be right back',
       emoji: ':brb:',
+      expiration: date.valueOf()
     });
   });
 
@@ -71,8 +74,8 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
@@ -81,6 +84,7 @@ describe('getStatusForUserEvent', () => {
       expect(status).toEqual({
         text: 'Be right back',
         emoji: ':brb:',
+        expiration: date.valueOf()
       });
     });
 
@@ -104,8 +108,8 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
@@ -122,8 +126,8 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Free,
         },
@@ -137,8 +141,8 @@ describe('getStatusForUserEvent', () => {
         id: '1',
         name: 'Quick Chat',
         body: '',
-        startTime: new Date(),
-        endTime: new Date(),
+        startTime: date,
+        endTime: date,
         location: 'Zoom',
         showAs: ShowAs.Free,
       });
@@ -168,8 +172,8 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Busy,
         },
@@ -178,6 +182,7 @@ describe('getStatusForUserEvent', () => {
       expect(status).toEqual({
         text: 'Be right back',
         emoji: ':brb:',
+        expiration: date.valueOf()
       });
     });
 
@@ -201,14 +206,14 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Busy,
         },
       );
 
-      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
+      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:', expiration: date.valueOf() });
     });
 
     test(`Returns "Away" and :spiral_calendar_pad: when the user has no status mappings`, () => {
@@ -216,13 +221,13 @@ describe('getStatusForUserEvent', () => {
         id: '1',
         name: 'Quick Chat',
         body: '',
-        startTime: new Date(),
-        endTime: new Date(),
+        startTime: date,
+        endTime: date,
         location: 'Zoom',
         showAs: ShowAs.Busy,
       });
 
-      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
+      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:', expiration: date.valueOf() });
     });
   });
 
@@ -247,8 +252,8 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Tentative,
         },
@@ -257,6 +262,7 @@ describe('getStatusForUserEvent', () => {
       expect(status).toEqual({
         text: 'Be right back',
         emoji: ':brb:',
+        expiration: date.valueOf()
       });
     });
 
@@ -278,14 +284,14 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.Tentative,
         },
       );
 
-      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
+      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:', expiration: date.valueOf() });
     });
 
     test(`Returns "Away" and :spiral_calendar_pad: when the user has no status mappings`, () => {
@@ -293,13 +299,13 @@ describe('getStatusForUserEvent', () => {
         id: '1',
         name: 'Quick Chat',
         body: '',
-        startTime: new Date(),
-        endTime: new Date(),
+        startTime: date,
+        endTime: date,
         location: 'Zoom',
         showAs: ShowAs.Tentative,
       });
 
-      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:' });
+      expect(status).toEqual({ text: 'Away', emoji: ':spiral_calendar_pad:', expiration: date.valueOf() });
     });
   });
 
@@ -324,8 +330,8 @@ describe('getStatusForUserEvent', () => {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
-          endTime: new Date(),
+          startTime: date,
+          endTime: date,
           location: 'Zoom',
           showAs: ShowAs.OutOfOffice,
         },
@@ -334,17 +340,19 @@ describe('getStatusForUserEvent', () => {
       expect(status).toEqual({
         text: 'Be right back',
         emoji: ':brb:',
+        expiration: date.valueOf()
       });
     });
 
     describe('Given no status mappings', () => {
       test(`Returns "OOO until {date}" and :ooo: when the OOO event lasts beyond the current day`, () => {
-        const today = new Date();
+        const today = date;
+        const tomorrow = new Date(today.getDate() + 1);
         const status = getStatusForUserEvent(baseUserSettings, {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
+          startTime: date,
           endTime: {
             ...today,
             getDate: jest.fn(() => today.getDate() + 1),
@@ -355,16 +363,17 @@ describe('getStatusForUserEvent', () => {
           showAs: ShowAs.OutOfOffice,
         });
 
-        expect(status).toEqual({ text: 'OOO until tomorrow', emoji: ':ooo:' });
+        expect(status.text).toEqual('OOO until tomorrow');
+        expect(status.emoji).toEqual(':ooo:');
       });
 
       test(`Returns "OOO until {time}" in the user's timezone and :ooo: when the OOO event ends on the current day`, () => {
-        const today = new Date();
+        const today = date;
         const status = getStatusForUserEvent(baseUserSettings, {
           id: '1',
           name: 'Quick Chat',
           body: '',
-          startTime: new Date(),
+          startTime: date,
           endTime: {
             ...today,
             getDate: jest.fn(() => today.getDate()),
@@ -375,13 +384,14 @@ describe('getStatusForUserEvent', () => {
           showAs: ShowAs.OutOfOffice,
         });
 
-        expect(status).toEqual({ text: 'OOO until 2pm', emoji: ':ooo:' });
+        expect(status.text).toEqual('OOO until 2pm');
+        expect(status.emoji).toEqual(':ooo:');
       });
     });
 
     describe('Given no relevant status mappings', () => {
       test(`Returns "OOO until {date}" and :ooo: when the OOO event lasts beyond the current day`, () => {
-        const today = new Date();
+        const today = date;
         const status = getStatusForUserEvent(
           {
             ...baseUserSettings,
@@ -399,7 +409,7 @@ describe('getStatusForUserEvent', () => {
             id: '1',
             name: 'Quick Chat',
             body: '',
-            startTime: new Date(),
+            startTime: date,
             endTime: {
               ...today,
               getDate: jest.fn(() => today.getDate() + 1),
@@ -411,11 +421,12 @@ describe('getStatusForUserEvent', () => {
           },
         );
 
-        expect(status).toEqual({ text: 'OOO until tomorrow', emoji: ':ooo:' });
+        expect(status.text).toEqual('OOO until tomorrow');
+        expect(status.emoji).toEqual(':ooo:');
       });
 
       test(`Returns "OOO until {time}" and :ooo: when the OOO event ends on the current day`, () => {
-        const today = new Date();
+        const today = date;
         const status = getStatusForUserEvent(
           {
             ...baseUserSettings,
@@ -433,7 +444,7 @@ describe('getStatusForUserEvent', () => {
             id: '1',
             name: 'Quick Chat',
             body: '',
-            startTime: new Date(),
+            startTime: date,
             endTime: {
               ...today,
               getDate: jest.fn(() => today.getDate()),
@@ -445,7 +456,8 @@ describe('getStatusForUserEvent', () => {
           },
         );
 
-        expect(status).toEqual({ text: 'OOO until 2pm', emoji: ':ooo:' });
+        expect(status.text).toEqual('OOO until 2pm');
+        expect(status.emoji).toEqual(':ooo:');
       });
     });
   });


### PR DESCRIPTION
## Overview
This PR adds expiration to SlackStatus allowing users to see when you get out of your current calendar event.

## Implementation
Gets the `endDate` from the Outlook event that the status is for and converts it to Unix epoch time to use in [the Slack API](https://api.slack.com/methods/users.profile.set#status)

Expiration uses Unix epoch time which is a little weird but in Typescript you can call `.valueOf()` on a `Date` and it will give you the epoch time **IN MILLISECONDS**. `/ 1000` with `Math.floor()` to get Unix epoch seconds because Javascript is Javascript

## Testing
Tested locally and it works!
<img width="352" height="176" alt="image" src="https://github.com/user-attachments/assets/65041199-db8c-49b5-9752-042a5947b667" />
<img width="250" height="155" alt="image" src="https://github.com/user-attachments/assets/b23e115b-3493-4e08-a329-c9b6b9e9a716" />
