### PR TITLE
Fix CI/CD by bumping serverless from 3.39.0 -> 3.40.0 to support Node versions >20.18.1 (Current one used in CI/CD is 20.19.4)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/node": "22.7.5",
         "@types/simple-oauth2": "5.0.7",
         "jest": "29.7.0",
-        "serverless": "3.39.0",
+        "serverless": "3.40.0",
         "serverless-offline": "13.6.0",
         "serverless-plugin-include-dependencies": "6.1.1",
         "serverless-plugin-typescript": "2.1.5",
@@ -12149,9 +12149,9 @@
       }
     },
     "node_modules/serverless": {
-      "version": "3.39.0",
-      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.39.0.tgz",
-      "integrity": "sha512-FHI3fhe4TRS8+ez/KA7HmO3lt3fAynO+N1pCCzYRThMWG0J8RWCI0BI+K0mw9+sEV+QpBCpZRZbuGyUaTsaQew==",
+      "version": "3.40.0",
+      "resolved": "https://registry.npmjs.org/serverless/-/serverless-3.40.0.tgz",
+      "integrity": "sha512-6vUSIUqBkhZeIpFz0howqKlT1BNjYxOrucvvSICKCEsxVS9MbTJokGkykDrpr/k4Io3WI8tcvrf25+U5Ynf3lw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "@types/node": "22.7.5",
     "@types/simple-oauth2": "5.0.7",
     "jest": "29.7.0",
-    "serverless": "3.39.0",
+    "serverless": "3.40.0",
     "serverless-offline": "13.6.0",
     "serverless-plugin-include-dependencies": "6.1.1",
     "serverless-plugin-typescript": "2.1.5",


### PR DESCRIPTION
## Description
Updates `package.json` and `package-lock.json` so CI/CD can run with Node 20.19.4 with serverless 3.40.0

## Resources
[Relevant Serverless Github issue here](https://github.com/serverless/serverless/issues/12936#issuecomment-2549292037)
[Serverless 3.40.0 release notes](https://github.com/serverless/serverless/releases/tag/v3.40.0)
[Files changed between Serverless 3.39.0 and 3.40.0](https://github.com/serverless/serverless/compare/v3.39.0...v3.40.0)