### PR TITLE
Add ability to have certain meetings put you into DND with `set` command

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -114,7 +114,7 @@ export const updateOne = async (us: UserSettings) => {
   const presence = relevantEvent && relevantEvent.showAs > ShowAs.Tentative ? 'away' : 'auto';
 
   const promises: Promise<UserSettings | void>[] = [];
-  if (shouldUpdateSlackStatus || us.email.toLowerCase() === 'blaine.traudt@hudl.com') {
+  if (shouldUpdateSlackStatus) {
     promises.push(
       setUserStatus(us.email, us.slackToken, status),
       setUserPresence(us.email, us.slackToken, presence),

--- a/src/services/__tests__/slack.tests.ts
+++ b/src/services/__tests__/slack.tests.ts
@@ -1,20 +1,38 @@
-import { getUserByEmail } from '../slack';
+import { getUserByEmail, setUserDnd, setUserStatus } from '../slack';
 import { WebClient, WebAPIPlatformError } from '@slack/web-api';
 
 const mockLookupByEmail = jest.fn();
+const mockSetSnooze = jest.fn();
+const mockSetProfile = jest.fn();
+
 jest.mock('@slack/web-api', () => {
   return {
     WebClient: jest.fn().mockImplementation(() => {
       return {
         users: {
           lookupByEmail: mockLookupByEmail,
+          profile: {
+            set: mockSetProfile,
+          },
+        },
+        dnd: {
+          setSnooze: mockSetSnooze,
         },
       };
     }),
   };
 });
 
+// Mock the dependent functions
+jest.mock('../../utils/secrets');
+jest.mock('../dynamo');
+jest.mock('../../utils/urls');
+
 describe('getUserByEmail', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   describe('with empty token supplied', () => {
     test('returns undefined', async () => {
       const user = await getUserByEmail('', 'test@test.com');
@@ -59,6 +77,87 @@ describe('getUserByEmail', () => {
         } catch (e) {
           expect(e).toEqual(expectedError);
         }
+      });
+    });
+  });
+});
+
+describe('setUserDnd', () => {
+  const email = 'test@example.com';
+  const token = 'valid-token';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('with no token supplied', () => {
+    test('returns early and does not call Slack API', async () => {
+      await setUserDnd(email, undefined, { dnd: true, expiration: 2000000 });
+
+      expect(mockSetSnooze).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with dnd flag set to false', () => {
+    test('returns early and does not call Slack API', async () => {
+      await setUserDnd(email, token, { dnd: false, expiration: 2000000 });
+
+      expect(mockSetSnooze).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with no expiration provided', () => {
+    test('returns early and does not call Slack API', async () => {
+      await setUserDnd(email, token, { dnd: true });
+
+      expect(mockSetSnooze).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('with valid parameters', () => {
+    test('calls setSnooze with calculated minutes', async () => {
+      // Mock Date.now to return a fixed timestamp
+      const mockNow = jest.spyOn(Date, 'now').mockReturnValue(1000000);
+      const expiration = 1000000 + 30 * 60 * 1000; // 30 minutes from mocked now
+
+      mockSetSnooze.mockResolvedValueOnce({ ok: true });
+
+      await setUserDnd(email, token, { dnd: true, expiration });
+
+      expect(mockSetSnooze).toHaveBeenCalledWith({ num_minutes: 30 });
+
+      mockNow.mockRestore();
+    });
+  });
+});
+
+describe('setUserStatus', () => {
+  const email = 'test@example.com';
+  const token = 'valid-token';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('DND integration', () => {
+    test('calls profile set with correct parameters when DND is enabled', async () => {
+      const status = {
+        text: 'In a meeting',
+        emoji: ':calendar:',
+        expiration: 2000000,
+        dnd: true,
+      };
+
+      mockSetProfile.mockResolvedValueOnce({ ok: true });
+
+      await setUserStatus(email, token, status);
+
+      expect(mockSetProfile).toHaveBeenCalledWith({
+        profile: {
+          status_text: 'In a meeting',
+          status_emoji: ':calendar:',
+          status_expiration: 2000,
+        },
       });
     });
   });

--- a/src/services/dynamo.ts
+++ b/src/services/dynamo.ts
@@ -15,7 +15,6 @@ import { v4 as uuidv4 } from 'uuid';
 export type StatusMapping = {
   calendarText: string;
   slackStatus: SlackStatus;
-  dnd?: boolean;
 };
 
 export type ExportedSettings = {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -79,12 +79,12 @@ export const setUserStatus = async (email: string, token: string | undefined, st
   }
 };
 
-export const setUserDnd = async (email: string, token: string | undefined, expiration: number) => {
-  if (!token) return;
+export const setUserDnd = async (email: string, token: string | undefined, status: SlackStatus) => {
+  if (!token || !status.dnd || !status.expiration) return;
 
   const slackClient = new WebClient(token);
 
-  const num_milliseconds = Date.now().valueOf() - expiration;
+  const num_milliseconds = Date.now().valueOf() - status.expiration;
   const num_seconds = num_milliseconds / 1000;
   const num_minutes = Math.ceil(num_seconds / 60);
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -57,7 +57,9 @@ export const setUserPresence = async (email: string, token: string | undefined, 
 export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
 
-  console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`);
+  console.log(
+    `Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`,
+  );
 
   const slackClient = new WebClient(token);
 
@@ -70,6 +72,26 @@ export const setUserStatus = async (email: string, token: string | undefined, st
         status_emoji: status?.emoji || '',
         status_expiration: expiration_seconds,
       },
+    });
+  } catch (error) {
+    await handleError(error, email);
+  }
+};
+
+export const setUserDnd = async (email: string, token: string | undefined, expiration: number) => {
+  if (!token) return;
+
+  const slackClient = new WebClient(token);
+
+  const num_milliseconds = Date.now().valueOf() - expiration;
+  const num_seconds = num_milliseconds / 1000;
+  const num_minutes = Math.ceil(num_seconds / 60);
+
+  console.log(`Setting DND on for ${email} for ${num_minutes} minutes`);
+
+  try {
+    await slackClient.dnd.setSnooze({
+      num_minutes,
     });
   } catch (error) {
     await handleError(error, email);

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -7,6 +7,7 @@ export type SlackStatus = {
   text?: string;
   emoji?: string;
   expiration?: number;
+  dnd?: boolean;
 };
 
 export type SlackUserProfile = {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -1,11 +1,4 @@
-import {
-  WebClient,
-  ChatPostMessageArguments,
-  ErrorCode,
-  WebAPICallError,
-  WebAPIPlatformError,
-  DndInfoResponse,
-} from '@slack/web-api';
+import { WebClient, ChatPostMessageArguments, ErrorCode, WebAPICallError, WebAPIPlatformError } from '@slack/web-api';
 import { clearUserTokens } from './dynamo';
 import { getSlackSecretWithKey } from '../utils/secrets';
 import { slackInstallUrl } from '../utils/urls';
@@ -64,9 +57,7 @@ export const setUserPresence = async (email: string, token: string | undefined, 
 export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
 
-  console.log(
-    `Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`,
-  );
+  console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`);
 
   const slackClient = new WebClient(token);
 
@@ -83,14 +74,6 @@ export const setUserStatus = async (email: string, token: string | undefined, st
   } catch (error) {
     await handleError(error, email);
   }
-};
-
-export const getUserDndInfo = async (token: string, slackUserId: string): Promise<DndInfoResponse | undefined> => {
-  if (!token) return;
-
-  const slackClient = new WebClient(token);
-  const response = await slackClient.dnd.info({ user: slackUserId });
-  return response;
 };
 
 export const getUserInfo = async (token: string, slackUserId: string): Promise<SlackUserProfile | undefined> => {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -1,4 +1,11 @@
-import { WebClient, ChatPostMessageArguments, ErrorCode, WebAPICallError, WebAPIPlatformError } from '@slack/web-api';
+import {
+  WebClient,
+  ChatPostMessageArguments,
+  ErrorCode,
+  WebAPICallError,
+  WebAPIPlatformError,
+  DndInfoResponse,
+} from '@slack/web-api';
 import { clearUserTokens } from './dynamo';
 import { getSlackSecretWithKey } from '../utils/secrets';
 import { slackInstallUrl } from '../utils/urls';
@@ -57,7 +64,9 @@ export const setUserPresence = async (email: string, token: string | undefined, 
 export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
 
-  console.log(`Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`);
+  console.log(
+    `Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`,
+  );
 
   const slackClient = new WebClient(token);
 
@@ -74,6 +83,14 @@ export const setUserStatus = async (email: string, token: string | undefined, st
   } catch (error) {
     await handleError(error, email);
   }
+};
+
+export const getUserDndInfo = async (token: string, slackUserId: string): Promise<DndInfoResponse | undefined> => {
+  if (!token) return;
+
+  const slackClient = new WebClient(token);
+  const response = await slackClient.dnd.info({ user: slackUserId });
+  return response;
 };
 
 export const getUserInfo = async (token: string, slackUserId: string): Promise<SlackUserProfile | undefined> => {

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -58,12 +58,12 @@ export const setUserPresence = async (email: string, token: string | undefined, 
 export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
 
-  // Fire off setUserDnd as well in the background
-  setUserDnd(email, token, status);
-
   console.log(
     `Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`,
   );
+
+  // Fire off setUserDnd as well in the background
+  setUserDnd(email, token, status);
 
   const slackClient = new WebClient(token);
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -87,7 +87,7 @@ export const setUserDnd = async (email: string, token: string | undefined, statu
 
   const slackClient = new WebClient(token);
 
-  const num_milliseconds = Date.now().valueOf() - status.expiration;
+  const num_milliseconds = status.expiration - Date.now().valueOf();
   const num_seconds = num_milliseconds / 1000;
   const num_minutes = Math.ceil(num_seconds / 60);
 

--- a/src/services/slack.ts
+++ b/src/services/slack.ts
@@ -58,6 +58,9 @@ export const setUserPresence = async (email: string, token: string | undefined, 
 export const setUserStatus = async (email: string, token: string | undefined, status: SlackStatus) => {
   if (!token) return;
 
+  // Fire off setUserDnd as well in the background
+  setUserDnd(email, token, status);
+
   console.log(
     `Setting Slack status to ${status.text} with emoji ${status.emoji} for ${email} until ${status.expiration}`,
   );

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -92,9 +92,9 @@ export const serializeStatusMappings = ({ defaultStatus, statusMappings }: UserS
       '\n',
       ...statusMappings.map(
         (m) =>
-          `\n${m.slackStatus.emoji || ':transparent:'} \`${m.calendarText}\` ${
-            m.slackStatus.text ? `uses status \`${m.slackStatus.text}\`` : ''
-          }`,
+          `\n${m.slackStatus.emoji || ':transparent:'} \`${m.calendarText}\`${
+            m.slackStatus.text ? ` uses status \`${m.slackStatus.text}\`` : ''
+          }${m.slackStatus.dnd ? ' and toggles DND' : ''}`,
       ),
     );
   }

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -137,8 +137,8 @@ const handleSet = async (userSettings: UserSettings, argList: string[]): Promise
   if (!args.meeting) {
     return `You must specify a meeting using \`meeting="My Meeting"\`.`;
   }
-  // Checks if dnd is "True". If first letter isn't 't' or if arg not provided assume false
-  const dnd = args.dnd?.toLowerCase().startsWith('t');
+  // Checks if dnd is "True". If arg not provided assume false
+  const dnd = args.dnd?.toLowerCase() === 'true';
 
   const slackStatus = {
     text: args.message || args.meeting,

--- a/src/slackbot.ts
+++ b/src/slackbot.ts
@@ -137,13 +137,14 @@ const handleSet = async (userSettings: UserSettings, argList: string[]): Promise
   if (!args.meeting) {
     return `You must specify a meeting using \`meeting="My Meeting"\`.`;
   }
+  // Checks if dnd is "True". If first letter isn't 't' or if arg not provided assume false
+  const dnd = args.dnd?.toLowerCase().startsWith('t');
 
   const slackStatus = {
     text: args.message || args.meeting,
     emoji: args.emoji,
+    dnd,
   };
-  // Checks if dnd is "True". If first letter isn't 't' or if arg not provided assume false
-  const dnd = args.dnd?.toLowerCase().startsWith('t');
 
   const updatedMappings = userSettings.statusMappings || [];
   const existingMapping = updatedMappings.find(
@@ -152,9 +153,8 @@ const handleSet = async (userSettings: UserSettings, argList: string[]): Promise
 
   if (existingMapping) {
     existingMapping.slackStatus = slackStatus;
-    existingMapping.dnd = dnd;
   } else {
-    updatedMappings.push({ calendarText: args.meeting, slackStatus, dnd });
+    updatedMappings.push({ calendarText: args.meeting, slackStatus });
   }
 
   const slackPromise =

--- a/src/slackbot/__tests__/slackbot.tests.ts
+++ b/src/slackbot/__tests__/slackbot.tests.ts
@@ -1,0 +1,156 @@
+import { serializeStatusMappings } from '../../slackbot';
+import { UserSettings, StatusMapping } from '../../services/dynamo';
+
+describe('serializeStatusMappings', () => {
+  const baseUserSettings: UserSettings = {
+    email: 'test@example.com',
+    statusMappings: [],
+  };
+
+  describe('DND display functionality', () => {
+    test('shows "and toggles DND" when dnd is true', () => {
+      const userSettings: UserSettings = {
+        ...baseUserSettings,
+        statusMappings: [
+          {
+            calendarText: 'Squad Meeting',
+            slackStatus: {
+              text: 'In squad meeting',
+              emoji: ':calendar:',
+              dnd: true,
+            },
+          },
+        ],
+      };
+
+      const result = serializeStatusMappings(userSettings);
+
+      expect(result).toContain('and toggles DND');
+      expect(result).toContain(':calendar: `Squad Meeting` uses status `In squad meeting` and toggles DND');
+    });
+
+    test('does not show DND text when dnd is false', () => {
+      const userSettings: UserSettings = {
+        ...baseUserSettings,
+        statusMappings: [
+          {
+            calendarText: 'Regular Meeting',
+            slackStatus: {
+              text: 'In a meeting',
+              emoji: ':calendar:',
+              dnd: false,
+            },
+          },
+        ],
+      };
+
+      const result = serializeStatusMappings(userSettings);
+
+      expect(result).not.toContain('and toggles DND');
+      expect(result).toContain(':calendar: `Regular Meeting` uses status `In a meeting`');
+    });
+
+    test('does not show DND text when dnd is undefined', () => {
+      const userSettings: UserSettings = {
+        ...baseUserSettings,
+        statusMappings: [
+          {
+            calendarText: 'Regular Meeting',
+            slackStatus: {
+              text: 'In a meeting',
+              emoji: ':calendar:',
+            },
+          },
+        ],
+      };
+
+      const result = serializeStatusMappings(userSettings);
+
+      expect(result).not.toContain('and toggles DND');
+      expect(result).toContain(':calendar: `Regular Meeting` uses status `In a meeting`');
+    });
+
+    test('handles multiple mappings with mixed DND settings', () => {
+      const userSettings: UserSettings = {
+        ...baseUserSettings,
+        statusMappings: [
+          {
+            calendarText: 'Squad Meeting',
+            slackStatus: {
+              text: 'In squad meeting',
+              emoji: ':calendar:',
+              dnd: true,
+            },
+          },
+          {
+            calendarText: 'Regular Meeting',
+            slackStatus: {
+              text: 'In a meeting',
+              emoji: ':office:',
+              dnd: false,
+            },
+          },
+          {
+            calendarText: 'Daily Standup',
+            slackStatus: {
+              text: 'Daily standup',
+              emoji: ':speech_balloon:',
+            },
+          },
+        ],
+      };
+
+      const result = serializeStatusMappings(userSettings);
+
+      expect(result).toContain(':calendar: `Squad Meeting` uses status `In squad meeting` and toggles DND');
+      expect(result).toContain(':office: `Regular Meeting` uses status `In a meeting`');
+      expect(result).toContain(':speech_balloon: `Daily Standup` uses status `Daily standup`');
+
+      // Count occurrences of "and toggles DND" - should only appear once
+      const dndMatches = result.match(/and toggles DND/g);
+      expect(dndMatches).toHaveLength(1);
+    });
+
+    test('handles mapping without status text but with DND', () => {
+      const userSettings: UserSettings = {
+        ...baseUserSettings,
+        statusMappings: [
+          {
+            calendarText: 'Focus Time',
+            slackStatus: {
+              emoji: ':no_entry:',
+              dnd: true,
+            },
+          },
+        ],
+      };
+
+      const result = serializeStatusMappings(userSettings);
+
+      expect(result).toContain(':no_entry: `Focus Time` and toggles DND');
+      expect(result).not.toContain('uses status');
+    });
+  });
+
+  describe('existing functionality', () => {
+    test('displays default status when no status mappings exist', () => {
+      const userSettings: UserSettings = {
+        ...baseUserSettings,
+        defaultStatus: {
+          text: 'Available',
+          emoji: ':white_check_mark:',
+        },
+      };
+
+      const result = serializeStatusMappings(userSettings);
+
+      expect(result).toContain('*Your default status is*: :white_check_mark: `Available`');
+    });
+
+    test('handles no default status and no mappings', () => {
+      const result = serializeStatusMappings(baseUserSettings);
+
+      expect(result).toContain('*Your default status is*: _Not set_');
+    });
+  });
+});


### PR DESCRIPTION
## Overview
@Foshkey has a feature request for the ability to have certain meetings (like squad health checks or retros) automatically put the user into DND. This feature will default to false and only take effect if the user explicitly sets it to true.

## Implementation plan
0. Add the scope to allow for `dnd:write` to the app. **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/f47a2356b5422d53e227cba39cf3bc6d4f9247b5)**

1. [Add an additional param to set](https://github.com/hudl/CalendarToSlack/wiki) called "dnd" with a true/false variable that is not required and defaults to `false` . Will need to update the wiki after this change. [Can add the arg here](https://github.com/hudl/CalendarToSlack/blob/523ca30377fb590f0bf7d5ab0de38d37dce9282d/src/slackbot.ts#L104) and have `handleSet` read the arg. Will probably store the arg in an optional entry [in StatusMapping](https://github.com/hudl/CalendarToSlack/blob/523ca30377fb590f0bf7d5ab0de38d37dce9282d/src/services/dynamo.ts#L15) called `dnd` that is a boolean. (can't use snooze verbage since it is already in use in the app with [settings snoozed=true](https://github.com/hudl/CalendarToSlack/wiki#settings-commands)) **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/a2b721712dc6bb0daf81b7f70010b4e365fe5857)** **[REFACTOR](https://github.com/hudl/CalendarToSlack/pull/108/commits/e3410ec6e8f9ac11464dc74dd5806bd9d0a4c461)**

2. ~~Use the [dnd.info API](https://api.slack.com/methods/dnd.info) to get if the user has a snooze that is longer than the duration of the meeting they have DND on for (don't want to override when someone is on holiday for example). [Could be slid in here](https://github.com/hudl/CalendarToSlack/blob/523ca30377fb590f0bf7d5ab0de38d37dce9282d/src/services/slack.ts#L77) as a `getUserDndInfo()` function. **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/ce663f77d7fee8bd5117174fa54ca3dc641038fd)**~~ **[REVERT](https://github.com/hudl/CalendarToSlack/pull/108/commits/1103856d8f2a6ad8b4a784a10c562aff26148698)** The [dnd.setSnooze API](https://api.slack.com/methods/dnd.setSnooze) already handles this case so this is no longer needed!

3. Use the [dnd.setSnooze API](https://api.slack.com/methods/dnd.setSnooze) to set the snooze to the `num_minutes` that the meeting is. [Could be slid in here as well](https://github.com/hudl/CalendarToSlack/blob/523ca30377fb590f0bf7d5ab0de38d37dce9282d/src/services/slack.ts#L77) as a `setUserDnd()` function. **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/5a162ffa39e4c125eea43c3a17b9121331ba8ec8)** **[REFACTOR](https://github.com/hudl/CalendarToSlack/pull/108/commits/4060a3e601080f2a3144e152fb21c45b4d2cbbe8)** **[FIX](https://github.com/hudl/CalendarToSlack/pull/108/commits/c0dbc18c442d096507f1e9be7eb978215e3eb161)**

4. ~~Add the logic to anywhere in the code where `setUserStatus()` is~~ Easier and cleaner to just call `setUserDnd()` from `setUserStatus()`. **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/aa5fa9857ad05159d08d7aaff68742f64606f67a)**

5. Update the output [in handleShow](https://github.com/hudl/CalendarToSlack/blob/523ca30377fb590f0bf7d5ab0de38d37dce9282d/src/slackbot.ts#L124) to show if a meeting will turn on DND or not **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/fcd9f5ad09b393aa903db35feffc713acf42bf62)**

6. Write tests **[DONE](https://github.com/hudl/CalendarToSlack/pull/108/commits/5765345b27777e4f690eff12890f7e56d881f152)**

7. Update [the wiki](https://github.com/hudl/CalendarToSlack/wiki) (After PR is merged)